### PR TITLE
Version 0.1.0-alpha

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+2019-08-13 version 0.1.0-alpha
+
+## New features
+
+* Add tests for all components
+* Add an extension `NunjucksExtension` that preprocesses Nunjucks templates
+* Add an subclass of Undefined, `NunjucksUndefined`, that deals with instances where Nunjucks is more forgiving that Jinja
+* Create an example of a Jinja Environment that handles almost all incompatibilities between Nunjucks and Jinja in the govuk-frontend templates
+* Add a command-line tool, `scripts/njk-to-j2.py` that can be used for debugging the extension
+
+## Bugfixes
+
+* Fix bug with test helper `normalise_whitespace`
+
 2018-09-21 version 0.0.1
 
 * Initial commit

--- a/govuk_frontend/templates.py
+++ b/govuk_frontend/templates.py
@@ -6,6 +6,13 @@ import os.path as path
 
 
 def njk_to_j2(template):
+
+    # Some component templates (such as radios) use `items` as the key of
+    # an object element. However `items` is also the name of a dictionary
+    # method in Python, and Jinja2 will prefer to return this attribute
+    # over the dict item.
+    template = template.replace(".items", "['items']")
+
     return template
 
 

--- a/govuk_frontend/templates.py
+++ b/govuk_frontend/templates.py
@@ -28,6 +28,11 @@ def njk_to_j2(template):
     # Nunjucks uses elseif, Jinja uses elif
     template = template.replace("elseif", "elif")
 
+    # Some component templates (such as input) call macros with params as
+    # an object which has unqoted keys. This causes Jinja to silently
+    # ignore the values.
+    template = re.sub(r"""^([ ]*)([^ '"#\r\n:]+?)\s*:""", r"\1'\2':", template, flags=re.M)
+
     return template
 
 

--- a/govuk_frontend/templates.py
+++ b/govuk_frontend/templates.py
@@ -4,6 +4,10 @@ import jinja2
 import os.path as path
 
 
+def njk_to_j2(template):
+    return template
+
+
 class Environment(jinja2.Environment):
     def __init__(self, **kwargs):
         kwargs.setdefault("loader",

--- a/govuk_frontend/templates.py
+++ b/govuk_frontend/templates.py
@@ -6,7 +6,11 @@ import os.path as path
 
 class Environment(jinja2.Environment):
     def __init__(self, **kwargs):
-        kwargs.setdefault("loader", jinja2.loaders.FileSystemLoader("node_modules/govuk-frontend"))
+        kwargs.setdefault("loader",
+            jinja2.loaders.FileSystemLoader([
+                "node_modules/govuk-frontend",
+                "node_modules/govuk-frontend/components",
+        ]))
         super().__init__(**kwargs)
 
     def join_path(self, template, parent):

--- a/govuk_frontend/templates.py
+++ b/govuk_frontend/templates.py
@@ -1,5 +1,6 @@
 
 import jinja2
+import jinja2.ext
 
 import os.path as path
 
@@ -8,10 +9,19 @@ def njk_to_j2(template):
     return template
 
 
+class NunjucksExtension(jinja2.ext.Extension):
+    def preprocess(self, source, name, filename=None):
+        if filename and filename.endswith(".njk"):
+            return njk_to_j2(source)
+        else:
+            return source
+
+
 class Environment(jinja2.Environment):
     def __init__(self, **kwargs):
+        kwargs.setdefault("extensions", [NunjucksExtension])
         kwargs.setdefault("loader",
-            jinja2.loaders.FileSystemLoader([
+            jinja2.FileSystemLoader([
                 "node_modules/govuk-frontend",
                 "node_modules/govuk-frontend/components",
         ]))

--- a/govuk_frontend/templates.py
+++ b/govuk_frontend/templates.py
@@ -25,6 +25,9 @@ def njk_to_j2(template):
     # class string.
     template = re.sub(r"\b(.+) if \1(?! else)", r"\1 if \1 else ''", template)
 
+    # Nunjucks uses elseif, Jinja uses elif
+    template = template.replace("elseif", "elif")
+
     return template
 
 

--- a/govuk_frontend/templates.py
+++ b/govuk_frontend/templates.py
@@ -40,6 +40,13 @@ def njk_to_j2(template):
     template = template.replace("macro govukFieldset(params)",
                                 "macro govukFieldset(params, caller=none)")
 
+    # The attributes field of params for govukInput is supposed to be a dictionary,
+    # and in the template for the input component the keys and values are iterated.
+    # In Python the default iterator for a dict is .keys(), but we want .items().
+    # This only works because our undefined implements .items().
+    template = template.replace("for attribute, value in params.attributes",
+                                "for attribute, value in params.attributes.items()")
+
     return template
 
 
@@ -70,6 +77,11 @@ class NunjucksUndefined(jinja2.runtime.Undefined):
         return self
 
     __getitem__ = __getattr__
+
+    # Allow treating undefined as an (empty) dictionary.
+    # This works because Undefined is an iterable.
+    def items(self):
+        return self
 
 
 class Environment(jinja2.Environment):

--- a/govuk_frontend/templates.py
+++ b/govuk_frontend/templates.py
@@ -33,6 +33,13 @@ def njk_to_j2(template):
     # ignore the values.
     template = re.sub(r"""^([ ]*)([^ '"#\r\n:]+?)\s*:""", r"\1'\2':", template, flags=re.M)
 
+    # govukFieldset can accept a call block argument, however the Jinja
+    # compiler does not detect this as the macro body is included from
+    # the template file. A workaround is to patch the declaration of the
+    # macro to include an explicit caller argument.
+    template = template.replace("macro govukFieldset(params)",
+                                "macro govukFieldset(params, caller=none)")
+
     return template
 
 

--- a/govuk_frontend/templates.py
+++ b/govuk_frontend/templates.py
@@ -17,6 +17,10 @@ class NunjucksExtension(jinja2.ext.Extension):
             return source
 
 
+class NunjucksUndefined(jinja2.runtime.Undefined):
+    __slots__ = ()
+
+
 class Environment(jinja2.Environment):
     def __init__(self, **kwargs):
         kwargs.setdefault("extensions", [NunjucksExtension])
@@ -25,6 +29,7 @@ class Environment(jinja2.Environment):
                 "node_modules/govuk-frontend",
                 "node_modules/govuk-frontend/components",
         ]))
+        kwargs.setdefault("undefined", NunjucksUndefined)
         super().__init__(**kwargs)
 
     def join_path(self, template, parent):

--- a/govuk_frontend/templates.py
+++ b/govuk_frontend/templates.py
@@ -13,6 +13,12 @@ def njk_to_j2(template):
     # over the dict item.
     template = template.replace(".items", "['items']")
 
+    # Some component templates (such as radios) append the loop index to a
+    # string. As the loop index is an integer this causes a TypeError in
+    # Python. Jinja2 has an operator `~` for string concatenation that
+    # converts integers to strings.
+    template = template.replace("+ loop.index", "~ loop.index")
+
     return template
 
 

--- a/govuk_frontend/templates.py
+++ b/govuk_frontend/templates.py
@@ -3,6 +3,7 @@ import jinja2
 import jinja2.ext
 
 import os.path as path
+import re
 
 
 def njk_to_j2(template):
@@ -18,6 +19,11 @@ def njk_to_j2(template):
     # Python. Jinja2 has an operator `~` for string concatenation that
     # converts integers to strings.
     template = template.replace("+ loop.index", "~ loop.index")
+
+    # Some component templates (such as radios and character-count) use an
+    # inline if-expression without an else statement to assemble a CSS
+    # class string.
+    template = re.sub(r"\b(.+) if \1(?! else)", r"\1 if \1 else ''", template)
 
     return template
 

--- a/govuk_frontend/templates.py
+++ b/govuk_frontend/templates.py
@@ -83,6 +83,14 @@ class NunjucksUndefined(jinja2.runtime.Undefined):
     def items(self):
         return self
 
+    # Allow escaping with Markup. This is required when
+    # autoescape is enabled. Debugging this issue was
+    # annoying; the error messages were not clear as to
+    # the cause of the issue (see upstream pull request
+    # for info https://github.com/pallets/jinja/pull/1047)
+    def __html__(self):
+        return str(self)
+
 
 class Environment(jinja2.Environment):
     def __init__(self, **kwargs):

--- a/govuk_frontend/templates.py
+++ b/govuk_frontend/templates.py
@@ -33,6 +33,23 @@ class NunjucksExtension(jinja2.ext.Extension):
 class NunjucksUndefined(jinja2.runtime.Undefined):
     __slots__ = ()
 
+    # copied from https://github.com/pallets/jinja/commit/19133d40593ced72eb28e230588abcc70d8b9f82
+    def __getattr__(self, _):
+        """Make undefined that is chainable, where both
+        __getattr__ and __getitem__ return itself rather than
+        raising an :exc:`UndefinedError`:
+        >>> foo = ChainableUndefined(name='foo')
+        >>> str(foo.bar['baz'])
+        ''
+        >>> foo.bar['baz'] + 42
+        Traceback (most recent call last):
+          ...
+        jinja2.exceptions.UndefinedError: 'foo' is undefined
+        """
+        return self
+
+    __getitem__ = __getattr__
+
 
 class Environment(jinja2.Environment):
     def __init__(self, **kwargs):

--- a/scripts/njk-to-j2.py
+++ b/scripts/njk-to-j2.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+
+"""
+Run njk_to_j2 against the a tree of Nunjucks templates.
+"""
+
+from govuk_frontend.templates import njk_to_j2
+
+from argparse import ArgumentParser
+from pathlib import Path
+from typing import Iterable, Tuple, Optional
+
+
+def iter_njk_templates(path: Path, root: Optional[Path] = None) -> Iterable[Tuple[Path, str]]:
+    if root is None:
+        root = path.resolve()
+    if path.is_dir():
+        for child in path.iterdir():
+            yield from iter_njk_templates(child, root=root)
+    elif path.is_file():
+        if path.suffix == ".njk":
+            f = path.relative_to(root)
+            yield f, path.read_text()
+
+
+def print_templates(templates: Iterable[Tuple[Path, str]]):
+    for path, template in templates:
+        print(f"+++ {path}")
+        print(template)
+
+
+def save_templates(templates: Iterable[Tuple[Path, str]], output_path: Optional[Path] = None):
+    for path, template in templates:
+        if output_path:
+            path = output_path / path
+        path.write_text(template)
+
+
+def main(argv=None):
+    parser = ArgumentParser(description=__doc__)
+    parser.add_argument("input", metavar="DIR", default=".",
+                        help="path to directories containing .njk files")
+    parser.add_argument("-o", "--output", nargs="?", const=True,
+                        help="save output")
+    args = parser.parse_args(argv)
+
+    input_path = Path(args.input)
+    if args.output:
+        if args.output is True:
+            output_path = input_path
+        else:
+            output_path = Path(args.output)
+
+    pipeline = iter_njk_templates(input_path)
+    pipeline = ((path, njk_to_j2(template)) for path, template in pipeline)
+    if args.output:
+        save_templates(pipeline, output_path=output_path)
+    else:
+        print_templates(pipeline)
+
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="govuk-frontend-python",
-    version="0.0.1",
+    version="0.1.0-alpha",
     author="Laurence de Bruxelles",
     author_email="author@example.com",
     description="Tools to use the GOV.UK Design System with Python apps",

--- a/tests/components/test_back_link.py
+++ b/tests/components/test_back_link.py
@@ -1,0 +1,45 @@
+
+import pytest
+
+
+def test_back_link(env):
+    template = env.from_string(
+"""
+{% from "back-link/macro.njk" import govukBackLink %}
+
+{{ govukBackLink({
+  "href": "#"
+}) }}
+"""
+    )
+    assert (
+        pytest.helpers.normalise_whitespace(template.render())
+        ==
+        pytest.helpers.normalise_whitespace(
+"""
+<a href="#" class="govuk-back-link">Back</a>
+"""
+        )
+    )
+
+
+def test_back_link_with_custom_text(env):
+    template = env.from_string(
+"""
+{% from "back-link/macro.njk" import govukBackLink %}
+
+{{ govukBackLink({
+  "href": "#",
+  "text": "Back to home"
+}) }}
+"""
+    )
+    assert (
+        pytest.helpers.normalise_whitespace(template.render())
+        ==
+        pytest.helpers.normalise_whitespace(
+"""
+<a href="#" class="govuk-back-link">Back to home</a>
+"""
+        )
+    )

--- a/tests/components/test_breadcrumbs.py
+++ b/tests/components/test_breadcrumbs.py
@@ -1,0 +1,225 @@
+
+import pytest
+
+
+def test_breadcrumbs(env):
+    template = env.from_string(
+"""
+{% from "breadcrumbs/macro.njk" import govukBreadcrumbs %}
+
+{{ govukBreadcrumbs({
+  "items": [
+    {
+      "text": "Section",
+      "href": "/section"
+    },
+    {
+      "text": "Sub-section",
+      "href": "/section/sub-section"
+    }
+  ]
+}) }}
+"""
+    )
+    assert (
+        pytest.helpers.normalise_whitespace(template.render())
+        ==
+        pytest.helpers.normalise_whitespace(
+"""
+<div class="govuk-breadcrumbs">
+  <ol class="govuk-breadcrumbs__list">
+
+    <li class="govuk-breadcrumbs__list-item">
+      <a class="govuk-breadcrumbs__link" href="/section">Section</a>
+    </li>
+
+    <li class="govuk-breadcrumbs__list-item">
+      <a class="govuk-breadcrumbs__link" href="/section/sub-section">Sub-section</a>
+    </li>
+
+  </ol>
+</div>
+"""
+        )
+    )
+
+
+def test_breadcrumbs_with_one_level(env):
+    template = env.from_string(
+"""
+{% from "breadcrumbs/macro.njk" import govukBreadcrumbs %}
+
+{{ govukBreadcrumbs({
+  "items": [
+    {
+      "text": "Section",
+      "href": "/section"
+    }
+  ]
+}) }}
+"""
+    )
+    assert (
+        pytest.helpers.normalise_whitespace(template.render())
+        ==
+        pytest.helpers.normalise_whitespace(
+"""
+<div class="govuk-breadcrumbs">
+  <ol class="govuk-breadcrumbs__list">
+
+    <li class="govuk-breadcrumbs__list-item">
+      <a class="govuk-breadcrumbs__link" href="/section">Section</a>
+    </li>
+
+  </ol>
+</div>
+"""
+        )
+    )
+
+
+def test_breadcrumbs_with_multiple_levels(env):
+    template = env.from_string(
+"""
+{% from "breadcrumbs/macro.njk" import govukBreadcrumbs %}
+
+{{ govukBreadcrumbs({
+  "items": [
+    {
+      "text": "Home",
+      "href": "/"
+    },
+    {
+      "text": "Section",
+      "href": "/section"
+    },
+    {
+      "text": "Sub-section",
+      "href": "/section/sub-section"
+    },
+    {
+      "text": "Sub Sub-section",
+      "href": "/section/sub-section/sub-sub-section"
+    }
+  ]
+}) }}
+"""
+    )
+    assert (
+        pytest.helpers.normalise_whitespace(template.render())
+        ==
+        pytest.helpers.normalise_whitespace(
+"""
+<div class="govuk-breadcrumbs">
+  <ol class="govuk-breadcrumbs__list">
+
+    <li class="govuk-breadcrumbs__list-item">
+      <a class="govuk-breadcrumbs__link" href="/">Home</a>
+    </li>
+
+    <li class="govuk-breadcrumbs__list-item">
+      <a class="govuk-breadcrumbs__link" href="/section">Section</a>
+    </li>
+
+    <li class="govuk-breadcrumbs__list-item">
+      <a class="govuk-breadcrumbs__link" href="/section/sub-section">Sub-section</a>
+    </li>
+
+    <li class="govuk-breadcrumbs__list-item">
+      <a class="govuk-breadcrumbs__link" href="/section/sub-section/sub-sub-section">Sub Sub-section</a>
+    </li>
+
+  </ol>
+</div>
+"""
+        )
+    )
+
+
+def test_breadcrumbs_without_the_home_section(env):
+    template = env.from_string(
+"""
+{% from "breadcrumbs/macro.njk" import govukBreadcrumbs %}
+
+{{ govukBreadcrumbs({
+  "items": [
+    {
+      "text": "Service Manual",
+      "href": "/service-manual"
+    },
+    {
+      "text": "Agile Delivery",
+      "href": "/service-manual/agile-delivery"
+    }
+  ]
+}) }}
+"""
+    )
+    assert (
+        pytest.helpers.normalise_whitespace(template.render())
+        ==
+        pytest.helpers.normalise_whitespace(
+"""
+<div class="govuk-breadcrumbs">
+  <ol class="govuk-breadcrumbs__list">
+
+    <li class="govuk-breadcrumbs__list-item">
+      <a class="govuk-breadcrumbs__link" href="/service-manual">Service Manual</a>
+    </li>
+
+    <li class="govuk-breadcrumbs__list-item">
+      <a class="govuk-breadcrumbs__link" href="/service-manual/agile-delivery">Agile Delivery</a>
+    </li>
+
+  </ol>
+</div>
+"""
+        )
+    )
+
+
+def test_breadcrumbs_with_last_breadcrumb_as_current_page(env):
+    template = env.from_string(
+"""
+{% from "breadcrumbs/macro.njk" import govukBreadcrumbs %}
+
+{{ govukBreadcrumbs({
+  "items": [
+    {
+      "text": "Home",
+      "href": "/"
+    },
+    {
+      "text": "Passports, travel and living abroad",
+      "href": "/browse/abroad"
+    },
+    {
+      "text": "Travel abroad"
+    }
+  ]
+}) }}
+"""
+    )
+    assert (
+        pytest.helpers.normalise_whitespace(template.render())
+        ==
+        pytest.helpers.normalise_whitespace(
+"""
+<div class="govuk-breadcrumbs">
+  <ol class="govuk-breadcrumbs__list">
+
+    <li class="govuk-breadcrumbs__list-item">
+      <a class="govuk-breadcrumbs__link" href="/">Home</a>
+    </li>
+
+    <li class="govuk-breadcrumbs__list-item">
+      <a class="govuk-breadcrumbs__link" href="/browse/abroad">Passports, travel and living abroad</a>
+    </li>
+
+    <li class="govuk-breadcrumbs__list-item" aria-current="page">Travel abroad</li>
+
+  </ol>
+</div>
+"""
+        )
+    )

--- a/tests/components/test_button.py
+++ b/tests/components/test_button.py
@@ -35,3 +35,126 @@ def test_default_example_macro():
         </button>"""
         ).strip()
     )
+
+
+def test_disabled_button_macro():
+    env = Environment()
+    template = env.from_string(dedent(
+        """
+        {% from "button/macro.njk" import govukButton %}
+
+        {{ govukButton({
+          "text": "Disabled button",
+          "disabled": true
+        }) }}"""
+    ))
+    assert (
+        template.render().strip() == dedent(
+        """
+        <button type="submit" disabled="disabled" aria-disabled="true" class="govuk-button govuk-button--disabled">
+          Disabled button
+        </button>"""
+        ).strip()
+    )
+
+
+def test_link_button_macro():
+    env = Environment()
+    template = env.from_string(dedent(
+        """
+        {% from "button/macro.njk" import govukButton %}
+
+        {{ govukButton({
+          "text": "Link button",
+          "href": "/",
+        }) }}"""
+    ))
+    assert (
+        template.render().strip() == dedent(
+        """
+        <a href="/" role="button" draggable="false" class="govuk-button">
+          Link button
+        </a>"""
+        ).strip()
+    )
+
+
+def test_disabled_link_button_macro():
+    env = Environment()
+    template = env.from_string(dedent(
+        """
+        {% from "button/macro.njk" import govukButton %}
+
+        {{ govukButton({
+          "text": "Link button",
+          "href": "/",
+          "disabled": true
+        }) }}"""
+    ))
+    assert (
+        template.render().strip() == dedent(
+        """
+        <a href="/" role="button" draggable="false" class="govuk-button govuk-button--disabled">
+          Link button
+        </a>"""
+        ).strip()
+    )
+
+
+def test_start_button_macro():
+    env = Environment()
+    template = env.from_string(dedent(
+        """
+        {% from "button/macro.njk" import govukButton %}
+
+        {{ govukButton({
+          "text": "Start now link button",
+          "href": "/",
+          "classes": "govuk-button--start"
+        }) }}"""
+    ))
+    assert (
+        template.render().strip() == dedent(
+        """
+        <a href="/" role="button" draggable="false" class="govuk-button govuk-button--start">
+          Start now link button
+        </a>"""
+        ).strip()
+    )
+
+
+def test_input_button_macro():
+    env = Environment()
+    template = env.from_string(dedent(
+        """
+        {% from "button/macro.njk" import govukButton %}
+
+        {{ govukButton({
+          "element": "input",
+          "name": "start-now",
+          "text": "Start now"
+        }) }}"""
+    ))
+    assert (
+        template.render().strip() == """<input value="Start now" name="start-now" type="submit" class="govuk-button">"""
+    )
+
+
+def test_disabled_input_button_macro():
+    env = Environment()
+    template = env.from_string(dedent(
+        """
+        {% from "button/macro.njk" import govukButton %}
+
+        {{ govukButton({
+          "element": "input",
+          "text": "Explicit input button disabled",
+          "disabled": true
+        }) }}"""
+    ))
+    assert (
+        template.render().strip() == (
+            """<input value="Explicit input button disabled" type="submit" disabled="disabled" """
+            """aria-disabled="true" class="govuk-button govuk-button--disabled">"""
+        )
+    )

--- a/tests/components/test_button.py
+++ b/tests/components/test_button.py
@@ -1,0 +1,37 @@
+from textwrap import dedent
+
+from govuk_frontend.templates import Environment
+
+
+def test_default_example():
+    env = Environment()
+    template = env.get_template("components/button/template.njk")
+
+    assert (
+        template.render(params={"text": "Save and continue"}).strip() == dedent(
+            """
+            <button type="submit" class="govuk-button">
+              Save and continue
+            </button>"""
+        ).strip()
+    )
+
+
+def test_default_example_macro():
+    env = Environment()
+    template = env.from_string(dedent(
+        """
+        {% from "components/button/macro.njk" import govukButton %}
+
+        {{ govukButton({
+          "text": "Save and continue"
+        }) }}"""
+    ))
+    assert (
+        template.render().strip() == dedent(
+        """
+        <button type="submit" class="govuk-button">
+          Save and continue
+        </button>"""
+        ).strip()
+    )

--- a/tests/components/test_character_count.py
+++ b/tests/components/test_character_count.py
@@ -1,0 +1,350 @@
+
+import pytest
+
+
+@pytest.mark.xfail(reason="inline if-expression not targeted by regex")
+def test_character_count(env):
+    template = env.from_string(
+"""
+{% from "character-count/macro.njk" import govukCharacterCount %}
+
+{{ govukCharacterCount({
+  "name": "more-detail",
+  "id": "more-detail",
+  "maxlength": 10,
+  "label": {
+    "text": "Can you provide more detail?"
+  }
+}) }}
+"""
+    )
+    assert (
+        pytest.helpers.normalise_whitespace(template.render())
+        ==
+        pytest.helpers.normalise_whitespace(
+"""
+<div class="govuk-character-count" data-module="character-count" data-maxlength="10">
+
+<div class="govuk-form-group">
+  <label class="govuk-label" for="more-detail">
+    Can you provide more detail?
+  </label>
+
+  <textarea class="govuk-textarea js-character-count " id="more-detail" name="more-detail" rows="5"></textarea>
+</div>
+
+  <span id="more-detail-info" class="govuk-hint govuk-character-count__message" aria-live="polite">
+    You can enter up to 10 characters
+  </span>
+</div>
+"""
+        )
+    )
+
+
+@pytest.mark.xfail(reason="inline if-expression not targeted by regex")
+def test_character_count_with_hint(env):
+    template = env.from_string(
+"""
+{% from "character-count/macro.njk" import govukCharacterCount %}
+
+{{ govukCharacterCount({
+  "name": "with-hint",
+  "id": "with-hint",
+  "maxlength": 10,
+  "label": {
+    "text": "Can you provide more detail?"
+  },
+  "hint": {
+    "text": "Don't include personal or financial information, eg your National Insurance number or credit card details."
+  }
+}) }}
+"""
+    )
+    assert (
+        pytest.helpers.normalise_whitespace(template.render())
+        ==
+        pytest.helpers.normalise_whitespace(
+"""
+<div class="govuk-character-count" data-module="character-count" data-maxlength="10">
+
+<div class="govuk-form-group">
+  <label class="govuk-label" for="with-hint">
+    Can you provide more detail?
+  </label>
+
+  <span id="with-hint-hint" class="govuk-hint">
+    Don&#39;t include personal or financial information, eg your National Insurance number or credit card details.
+  </span>
+
+  <textarea class="govuk-textarea js-character-count " id="with-hint" name="with-hint" rows="5" aria-describedby="with-hint-hint"></textarea>
+</div>
+
+  <span id="with-hint-info" class="govuk-hint govuk-character-count__message" aria-live="polite">
+    You can enter up to 10 characters
+  </span>
+</div>
+"""
+        )
+    )
+
+
+@pytest.mark.xfail(reason="inline if-expression not targeted by regex")
+def test_character_count_with_default_value(env):
+    template = env.from_string(
+"""
+{% from "character-count/macro.njk" import govukCharacterCount %}
+
+{{ govukCharacterCount({
+  "id": "with-default-value",
+  "name": "default-value",
+  "maxlength": 100,
+  "label": {
+    "text": "Full address"
+  },
+  "value": "221B Baker Street\nLondon\nNW1 6XE\n"
+}) }}
+"""
+    )
+    assert (
+        pytest.helpers.normalise_whitespace(template.render())
+        ==
+        pytest.helpers.normalise_whitespace(
+"""
+<div class="govuk-character-count" data-module="character-count" data-maxlength="100">
+
+<div class="govuk-form-group">
+  <label class="govuk-label" for="with-default-value">
+    Full address
+  </label>
+
+  <textarea class="govuk-textarea js-character-count " id="with-default-value" name="default-value" rows="5">221B Baker Street
+London
+NW1 6XE
+</textarea>
+</div>
+
+  <span id="with-default-value-info" class="govuk-hint govuk-character-count__message" aria-live="polite">
+    You can enter up to 100 characters
+  </span>
+</div>
+"""
+        )
+    )
+
+
+def test_character_count_with_default_value_exceeding_limit(env):
+    template = env.from_string(
+"""
+{% from "character-count/macro.njk" import govukCharacterCount %}
+
+{{ govukCharacterCount({
+  "id": "exceeding-characters",
+  "name": "exceeding",
+  "maxlength": 10,
+  "value": "221B Baker Street\nLondon\nNW1 6XE\n",
+  "label": {
+    "text": "Full address"
+  },
+  "errorMessage": {
+    "text": "Please do not exceed the maximum allowed limit"
+  }
+}) }}
+"""
+    )
+    assert (
+        pytest.helpers.normalise_whitespace(template.render())
+        ==
+        pytest.helpers.normalise_whitespace(
+"""
+<div class="govuk-character-count" data-module="character-count" data-maxlength="10">
+
+<div class="govuk-form-group govuk-form-group--error">
+  <label class="govuk-label" for="exceeding-characters">
+    Full address
+  </label>
+
+  <span id="exceeding-characters-error" class="govuk-error-message">
+    Please do not exceed the maximum allowed limit
+  </span>
+
+  <textarea class="govuk-textarea govuk-textarea--error js-character-count  govuk-textarea--error" id="exceeding-characters" name="exceeding" rows="5" aria-describedby="exceeding-characters-error">221B Baker Street
+London
+NW1 6XE
+</textarea>
+</div>
+
+  <span id="exceeding-characters-info" class="govuk-hint govuk-character-count__message" aria-live="polite">
+    You can enter up to 10 characters
+  </span>
+</div>
+"""
+        )
+    )
+
+
+@pytest.mark.xfail(reason="inline if-expression not targeted by regex")
+def test_charcter_count_with_custom_rows(env):
+    template = env.from_string(
+"""
+{% from "character-count/macro.njk" import govukCharacterCount %}
+
+{{ govukCharacterCount({
+  "id": "custom-rows",
+  "name": "custom",
+  "maxlength": 10,
+  "label": {
+    "text": "Full address"
+  },
+  "rows": 8
+}) }}
+"""
+    )
+    assert (
+        pytest.helpers.normalise_whitespace(template.render())
+        ==
+        pytest.helpers.normalise_whitespace(
+"""
+<div class="govuk-character-count" data-module="character-count" data-maxlength="10">
+
+<div class="govuk-form-group">
+  <label class="govuk-label" for="custom-rows">
+    Full address
+  </label>
+
+  <textarea class="govuk-textarea js-character-count " id="custom-rows" name="custom" rows="8"></textarea>
+</div>
+
+  <span id="custom-rows-info" class="govuk-hint govuk-character-count__message" aria-live="polite">
+    You can enter up to 10 characters
+  </span>
+</div>
+"""
+        )
+    )
+
+
+@pytest.mark.xfail(reason="inline if-expression not targeted by regex")
+def test_character_count_with_label_as_page_heading(env):
+    template = env.from_string(
+"""
+{% from "character-count/macro.njk" import govukCharacterCount %}
+
+{{ govukCharacterCount({
+  "id": "textarea-with-page-heading",
+  "name": "address",
+  "maxlength": 10,
+  "label": {
+    "text": "Full address",
+    "isPageHeading": true
+  }
+}) }}
+"""
+    )
+    assert (
+        pytest.helpers.normalise_whitespace(template.render())
+        ==
+        pytest.helpers.normalise_whitespace(
+"""
+<div class="govuk-character-count" data-module="character-count" data-maxlength="10">
+
+<div class="govuk-form-group">
+  <h1 class="govuk-label-wrapper">
+    <label class="govuk-label" for="textarea-with-page-heading">
+      Full address
+    </label>
+
+  </h1>
+
+  <textarea class="govuk-textarea js-character-count " id="textarea-with-page-heading" name="address" rows="5"></textarea>
+</div>
+
+  <span id="textarea-with-page-heading-info" class="govuk-hint govuk-character-count__message" aria-live="polite">
+    You can enter up to 10 characters
+  </span>
+</div>
+"""
+        )
+    )
+
+
+@pytest.mark.xfail(reason="inline if-expression not targeted by regex")
+def test_character_count_with_word_count(env):
+    template = env.from_string(
+"""
+{% from "character-count/macro.njk" import govukCharacterCount %}
+
+{{ govukCharacterCount({
+  "id": "word-count",
+  "name": "word-count",
+  "maxwords": 10,
+  "label": {
+    "text": "Full address"
+  }
+}) }}
+
+"""
+    )
+    assert (
+        pytest.helpers.normalise_whitespace(template.render())
+        ==
+        pytest.helpers.normalise_whitespace(
+"""
+<div class="govuk-character-count" data-module="character-count" data-maxwords="10">
+
+<div class="govuk-form-group">
+  <label class="govuk-label" for="word-count">
+    Full address
+  </label>
+
+  <textarea class="govuk-textarea js-character-count " id="word-count" name="word-count" rows="5"></textarea>
+</div>
+
+  <span id="word-count-info" class="govuk-hint govuk-character-count__message" aria-live="polite">
+    You can enter up to 10 words
+  </span>
+</div>
+"""
+        )
+    )
+
+
+@pytest.mark.xfail(reason="inline if-expression not targeted by regex")
+def test_character_count_with_threshold(env):
+    template = env.from_string(
+"""
+{% from "character-count/macro.njk" import govukCharacterCount %}
+
+{{ govukCharacterCount({
+  "id": "with-threshold",
+  "name": "with-threshold",
+  "maxlength": 10,
+  "threshold": 75,
+  "label": {
+    "text": "Full address"
+  }
+}) }}
+"""
+    )
+    assert (
+        pytest.helpers.normalise_whitespace(template.render())
+        ==
+        pytest.helpers.normalise_whitespace(
+"""
+<div class="govuk-character-count" data-module="character-count" data-maxlength="10" data-threshold="75">
+
+<div class="govuk-form-group">
+  <label class="govuk-label" for="with-threshold">
+    Full address
+  </label>
+
+  <textarea class="govuk-textarea js-character-count " id="with-threshold" name="with-threshold" rows="5"></textarea>
+</div>
+
+  <span id="with-threshold-info" class="govuk-hint govuk-character-count__message" aria-live="polite">
+    You can enter up to 10 characters
+  </span>
+</div>
+"""
+        )
+    )

--- a/tests/components/test_checkboxes.py
+++ b/tests/components/test_checkboxes.py
@@ -86,3 +86,636 @@ def test_checkboxes():
 """
         )
     )
+
+
+@pytest.mark.xfail(reason="Jinja undefined is stricter than Nunjucks undefined")
+def test_checkboxes_with_id_and_name(env):
+    template = env.from_string(
+"""
+{% from "checkboxes/macro.njk" import govukCheckboxes %}
+
+{{ govukCheckboxes({
+  "fieldset": {
+    "legend": {
+      "text": "What is your nationality?"
+    }
+  },
+  "hint": {
+    "text": "If you have dual nationality, select all options that are relevant to you."
+  },
+  "items": [
+    {
+      "name": "british",
+      "id": "item_british",
+      "value": "yes",
+      "text": "British"
+    },
+    {
+      "name": "irish",
+      "id": "item_irish",
+      "value": "irish",
+      "text": "Irish"
+    }
+  ]
+}) }}
+"""
+    )
+    assert (
+        pytest.helpers.normalise_whitespace(template.render())
+        ==
+        pytest.helpers.normalise_whitespace(
+"""
+<div class="govuk-form-group">
+
+  <fieldset class="govuk-fieldset" aria-describedby="undefined-hint">
+
+  <legend class="govuk-fieldset__legend">
+    What is your nationality?
+  </legend>
+
+  <span id="undefined-hint" class="govuk-hint">
+    If you have dual nationality, select all options that are relevant to you.
+  </span>
+
+  <div class="govuk-checkboxes">
+
+    <div class="govuk-checkboxes__item">
+      <input class="govuk-checkboxes__input" id="item_british" name="british" type="checkbox" value="yes">
+      <label class="govuk-label govuk-checkboxes__label" for="item_british">
+        British
+      </label>
+    </div>
+
+    <div class="govuk-checkboxes__item">
+      <input class="govuk-checkboxes__input" id="item_irish" name="irish" type="checkbox" value="irish">
+      <label class="govuk-label govuk-checkboxes__label" for="item_irish">
+        Irish
+      </label>
+    </div>
+
+  </div>
+  </fieldset>
+
+</div>
+"""
+        )
+    )
+
+
+def test_checkboxes_with_hints_on_items(env):
+    template = env.from_string(
+"""
+{% from "checkboxes/macro.njk" import govukCheckboxes %}
+
+{{ govukCheckboxes({
+  "fieldset": {
+    "legend": {
+      "text": "How do you want to sign in?",
+      "isPageHeading": true
+    }
+  },
+  "items": [
+    {
+      "name": "gateway",
+      "id": "government-gateway",
+      "value": "gov-gateway",
+      "text": "Sign in with Government Gateway",
+      "hint": {
+        "text": "You’ll have a user ID if you’ve registered for Self Assessment or filed a tax return online before."
+      }
+    },
+    {
+      "name": "verify",
+      "id": "govuk-verify",
+      "value": "gov-verify",
+      "text": "Sign in with GOV.UK Verify",
+      "hint": {
+        "text": "You’ll have an account if you’ve already proved your identity with either Barclays, CitizenSafe, Digidentity, Experian, Post Office, Royal Mail or SecureIdentity."
+      }
+    }
+  ]
+}) }}
+"""
+    )
+    assert (
+        pytest.helpers.normalise_whitespace(template.render())
+        ==
+        pytest.helpers.normalise_whitespace(
+"""
+<div class="govuk-form-group">
+
+  <fieldset class="govuk-fieldset">
+
+  <legend class="govuk-fieldset__legend">
+    <h1 class="govuk-fieldset__heading">
+      How do you want to sign in?
+    </h1>
+  </legend>
+
+  <div class="govuk-checkboxes">
+
+    <div class="govuk-checkboxes__item">
+      <input class="govuk-checkboxes__input" id="government-gateway" name="gateway" type="checkbox" value="gov-gateway" aria-describedby="government-gateway-item-hint">
+      <label class="govuk-label govuk-checkboxes__label" for="government-gateway">
+        Sign in with Government Gateway
+      </label>
+      <span id="government-gateway-item-hint" class="govuk-hint govuk-checkboxes__hint">
+        You’ll have a user ID if you’ve registered for Self Assessment or filed a tax return online before.
+      </span>
+    </div>
+
+    <div class="govuk-checkboxes__item">
+      <input class="govuk-checkboxes__input" id="govuk-verify" name="verify" type="checkbox" value="gov-verify" aria-describedby="govuk-verify-item-hint">
+      <label class="govuk-label govuk-checkboxes__label" for="govuk-verify">
+        Sign in with GOV.UK Verify
+      </label>
+      <span id="govuk-verify-item-hint" class="govuk-hint govuk-checkboxes__hint">
+        You’ll have an account if you’ve already proved your identity with either Barclays, CitizenSafe, Digidentity, Experian, Post Office, Royal Mail or SecureIdentity.
+      </span>
+    </div>
+
+  </div>
+  </fieldset>
+
+</div>
+"""
+        )
+    )
+
+
+def test_checkboxes_with_disabled_item(env):
+    template = env.from_string(
+"""
+{% from "checkboxes/macro.njk" import govukCheckboxes %}
+
+{{ govukCheckboxes({
+  "name": "colours",
+  "items": [
+    {
+      "value": "red",
+      "text": "Red"
+    },
+    {
+      "value": "green",
+      "text": "Green"
+    },
+    {
+      "value": "blue",
+      "text": "Blue",
+      "disabled": true
+    }
+  ]
+}) }}
+"""
+    )
+    assert (
+        pytest.helpers.normalise_whitespace(template.render())
+        ==
+        pytest.helpers.normalise_whitespace(
+"""
+<div class="govuk-form-group">
+
+  <div class="govuk-checkboxes">
+
+    <div class="govuk-checkboxes__item">
+      <input class="govuk-checkboxes__input" id="colours-1" name="colours" type="checkbox" value="red">
+      <label class="govuk-label govuk-checkboxes__label" for="colours-1">
+        Red
+      </label>
+    </div>
+
+    <div class="govuk-checkboxes__item">
+      <input class="govuk-checkboxes__input" id="colours-2" name="colours" type="checkbox" value="green">
+      <label class="govuk-label govuk-checkboxes__label" for="colours-2">
+        Green
+      </label>
+    </div>
+
+    <div class="govuk-checkboxes__item">
+      <input class="govuk-checkboxes__input" id="colours-3" name="colours" type="checkbox" value="blue" disabled>
+      <label class="govuk-label govuk-checkboxes__label" for="colours-3">
+        Blue
+      </label>
+    </div>
+
+  </div>
+
+</div>
+"""
+        )
+    )
+
+
+@pytest.mark.xfail(reason="issue#4: template tries to set variable in outer scope")
+def test_checkboxes_with_legend_as_page_heading(env):
+    template = env.from_string(
+"""
+{% from "checkboxes/macro.njk" import govukCheckboxes %}
+
+{{ govukCheckboxes({
+  "name": "waste",
+  "fieldset": {
+    "legend": {
+      "text": "Which types of waste do you transport regularly?",
+      "classes": "govuk-fieldset__legend--l",
+      "isPageHeading": true
+    }
+  },
+  "hint": {
+    "text": "Select all that apply"
+  },
+  "items": [
+    {
+      "value": "animal",
+      "text": "Waste from animal carcasses"
+    },
+    {
+      "value": "mines",
+      "text": "Waste from mines or quarries"
+    },
+    {
+      "value": "farm",
+      "text": "Farm or agricultural waste"
+    }
+  ]
+}) }}
+"""
+    )
+    assert (
+        pytest.helpers.normalise_whitespace(template.render())
+        ==
+        pytest.helpers.normalise_whitespace(
+"""
+<div class="govuk-form-group">
+
+  <fieldset class="govuk-fieldset" aria-describedby="waste-hint">
+
+  <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+    <h1 class="govuk-fieldset__heading">
+      Which types of waste do you transport regularly?
+    </h1>
+  </legend>
+
+  <span id="waste-hint" class="govuk-hint">
+    Select all that apply
+  </span>
+
+  <div class="govuk-checkboxes">
+
+    <div class="govuk-checkboxes__item">
+      <input class="govuk-checkboxes__input" id="waste-1" name="waste" type="checkbox" value="animal">
+      <label class="govuk-label govuk-checkboxes__label" for="waste-1">
+        Waste from animal carcasses
+      </label>
+    </div>
+
+    <div class="govuk-checkboxes__item">
+      <input class="govuk-checkboxes__input" id="waste-2" name="waste" type="checkbox" value="mines">
+      <label class="govuk-label govuk-checkboxes__label" for="waste-2">
+        Waste from mines or quarries
+      </label>
+    </div>
+
+    <div class="govuk-checkboxes__item">
+      <input class="govuk-checkboxes__input" id="waste-3" name="waste" type="checkbox" value="farm">
+      <label class="govuk-label govuk-checkboxes__label" for="waste-3">
+        Farm or agricultural waste
+      </label>
+    </div>
+
+  </div>
+  </fieldset>
+
+</div>
+"""
+        )
+    )
+
+
+@pytest.mark.xfail(reason="issue#4: template tries to set variable in outer scope")
+def test_checkboxes_with_a_medium_legend(env):
+    template = env.from_string(
+"""
+{% from "checkboxes/macro.njk" import govukCheckboxes %}
+
+{{ govukCheckboxes({
+  "name": "waste",
+  "fieldset": {
+    "legend": {
+      "text": "Which types of waste do you transport regularly?",
+      "classes": "govuk-fieldset__legend--m"
+    }
+  },
+  "hint": {
+    "text": "Select all that apply"
+  },
+  "errorMessage": {
+    "text": "Select which types of waste you transport regularly"
+  },
+  "items": [
+    {
+      "value": "animal",
+      "text": "Waste from animal carcasses"
+    },
+    {
+      "value": "mines",
+      "text": "Waste from mines or quarries"
+    },
+    {
+      "value": "farm",
+      "text": "Farm or agricultural waste"
+    }
+  ]
+}) }}
+"""
+    )
+    assert (
+        pytest.helpers.normalise_whitespace(template.render())
+        ==
+        pytest.helpers.normalise_whitespace(
+"""
+<div class="govuk-form-group govuk-form-group--error">
+
+  <fieldset class="govuk-fieldset" aria-describedby="waste-hint waste-error">
+
+  <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+    Which types of waste do you transport regularly?
+  </legend>
+
+  <span id="waste-hint" class="govuk-hint">
+    Select all that apply
+  </span>
+
+  <span id="waste-error" class="govuk-error-message">
+    Select which types of waste you transport regularly
+  </span>
+
+  <div class="govuk-checkboxes">
+
+    <div class="govuk-checkboxes__item">
+      <input class="govuk-checkboxes__input" id="waste-1" name="waste" type="checkbox" value="animal">
+      <label class="govuk-label govuk-checkboxes__label" for="waste-1">
+        Waste from animal carcasses
+      </label>
+    </div>
+
+    <div class="govuk-checkboxes__item">
+      <input class="govuk-checkboxes__input" id="waste-2" name="waste" type="checkbox" value="mines">
+      <label class="govuk-label govuk-checkboxes__label" for="waste-2">
+        Waste from mines or quarries
+      </label>
+    </div>
+
+    <div class="govuk-checkboxes__item">
+      <input class="govuk-checkboxes__input" id="waste-3" name="waste" type="checkbox" value="farm">
+      <label class="govuk-label govuk-checkboxes__label" for="waste-3">
+        Farm or agricultural waste
+      </label>
+    </div>
+
+  </div>
+  </fieldset>
+
+</div>
+"""
+        )
+    )
+
+
+def test_checkboxes_without_fieldset(env):
+    template = env.from_string(
+"""
+{% from "checkboxes/macro.njk" import govukCheckboxes %}
+
+{{ govukCheckboxes({
+  "name": "colours",
+  "items": [
+    {
+      "value": "red",
+      "text": "Red"
+    },
+    {
+      "value": "green",
+      "text": "Green"
+    },
+    {
+      "value": "blue",
+      "text": "Blue"
+    }
+  ]
+}) }}
+"""
+    )
+    assert (
+        pytest.helpers.normalise_whitespace(template.render())
+        ==
+        pytest.helpers.normalise_whitespace(
+"""
+<div class="govuk-form-group">
+
+  <div class="govuk-checkboxes">
+
+    <div class="govuk-checkboxes__item">
+      <input class="govuk-checkboxes__input" id="colours-1" name="colours" type="checkbox" value="red">
+      <label class="govuk-label govuk-checkboxes__label" for="colours-1">
+        Red
+      </label>
+    </div>
+
+    <div class="govuk-checkboxes__item">
+      <input class="govuk-checkboxes__input" id="colours-2" name="colours" type="checkbox" value="green">
+      <label class="govuk-label govuk-checkboxes__label" for="colours-2">
+        Green
+      </label>
+    </div>
+
+    <div class="govuk-checkboxes__item">
+      <input class="govuk-checkboxes__input" id="colours-3" name="colours" type="checkbox" value="blue">
+      <label class="govuk-label govuk-checkboxes__label" for="colours-3">
+        Blue
+      </label>
+    </div>
+
+  </div>
+
+</div>
+"""
+        )
+    )
+
+
+@pytest.mark.xfail(reason="issue#4: template tries to set variable in outer scope")
+def test_checkboxes_with_all_fieldset_attributes(env):
+    template = env.from_string(
+"""
+{% from "checkboxes/macro.njk" import govukCheckboxes %}
+
+{{ govukCheckboxes({
+  "idPrefix": "example",
+  "name": "example",
+  "fieldset": {
+    "classes": "app-fieldset--custom-modifier",
+    "attributes": {
+      "data-attribute": "value",
+      "data-second-attribute": "second-value"
+    },
+    "legend": {
+      "text": "What is your nationality?"
+    }
+  },
+  "hint": {
+    "text": "If you have dual nationality, select all options that are relevant to you."
+  },
+  "errorMessage": {
+    "text": "Please select an option"
+  },
+  "items": [
+    {
+      "value": "british",
+      "text": "British"
+    },
+    {
+      "value": "irish",
+      "text": "Irish"
+    },
+    {
+      "value": "other",
+      "text": "Citizen of another country"
+    }
+  ]
+}) }}
+"""
+    )
+    assert (
+        pytest.helpers.normalise_whitespace(template.render())
+        ==
+        pytest.helpers.normalise_whitespace(
+"""
+<div class="govuk-form-group govuk-form-group--error">
+
+  <fieldset class="govuk-fieldset app-fieldset--custom-modifier" aria-describedby="example-hint example-error" data-attribute="value" data-second-attribute="second-value">
+
+  <legend class="govuk-fieldset__legend">
+    What is your nationality?
+  </legend>
+
+  <span id="example-hint" class="govuk-hint">
+    If you have dual nationality, select all options that are relevant to you.
+  </span>
+
+  <span id="example-error" class="govuk-error-message">
+    Please select an option
+  </span>
+
+  <div class="govuk-checkboxes">
+
+    <div class="govuk-checkboxes__item">
+      <input class="govuk-checkboxes__input" id="example-1" name="example" type="checkbox" value="british">
+      <label class="govuk-label govuk-checkboxes__label" for="example-1">
+        British
+      </label>
+    </div>
+
+    <div class="govuk-checkboxes__item">
+      <input class="govuk-checkboxes__input" id="example-2" name="example" type="checkbox" value="irish">
+      <label class="govuk-label govuk-checkboxes__label" for="example-2">
+        Irish
+      </label>
+    </div>
+
+    <div class="govuk-checkboxes__item">
+      <input class="govuk-checkboxes__input" id="example-3" name="example" type="checkbox" value="other">
+      <label class="govuk-label govuk-checkboxes__label" for="example-3">
+        Citizen of another country
+      </label>
+    </div>
+
+  </div>
+  </fieldset>
+
+</div>
+"""
+        )
+    )
+
+
+@pytest.mark.xfail(reason="issue#4: template tries to set variable in outer scope")
+def test_checkboxes_with_error_message(env):
+    template = env.from_string(
+"""
+{% from "checkboxes/macro.njk" import govukCheckboxes %}
+
+{{ govukCheckboxes({
+  "name": "waste",
+  "errorMessage": {
+    "text": "Please select an option"
+  },
+  "fieldset": {
+    "legend": {
+      "text": "Which types of waste do you transport regularly?"
+    }
+  },
+  "items": [
+    {
+      "value": "animal",
+      "text": "Waste from animal carcasses"
+    },
+    {
+      "value": "mines",
+      "text": "Waste from mines or quarries"
+    },
+    {
+      "value": "farm",
+      "text": "Farm or agricultural waste"
+    }
+  ]
+}) }}
+"""
+    )
+    assert (
+        pytest.helpers.normalise_whitespace(template.render())
+        ==
+        pytest.helpers.normalise_whitespace(
+"""
+<div class="govuk-form-group govuk-form-group--error">
+
+  <fieldset class="govuk-fieldset" aria-describedby="waste-error">
+
+  <legend class="govuk-fieldset__legend">
+    Which types of waste do you transport regularly?
+  </legend>
+
+  <span id="waste-error" class="govuk-error-message">
+    Please select an option
+  </span>
+
+  <div class="govuk-checkboxes">
+
+    <div class="govuk-checkboxes__item">
+      <input class="govuk-checkboxes__input" id="waste-1" name="waste" type="checkbox" value="animal">
+      <label class="govuk-label govuk-checkboxes__label" for="waste-1">
+        Waste from animal carcasses
+      </label>
+    </div>
+
+    <div class="govuk-checkboxes__item">
+      <input class="govuk-checkboxes__input" id="waste-2" name="waste" type="checkbox" value="mines">
+      <label class="govuk-label govuk-checkboxes__label" for="waste-2">
+        Waste from mines or quarries
+      </label>
+    </div>
+
+    <div class="govuk-checkboxes__item">
+      <input class="govuk-checkboxes__input" id="waste-3" name="waste" type="checkbox" value="farm">
+      <label class="govuk-label govuk-checkboxes__label" for="waste-3">
+        Farm or agricultural waste
+      </label>
+    </div>
+
+  </div>
+  </fieldset>
+
+</div>
+"""
+        )
+    )

--- a/tests/components/test_checkboxes.py
+++ b/tests/components/test_checkboxes.py
@@ -1,0 +1,88 @@
+
+import pytest
+
+from govuk_frontend.templates import Environment
+
+
+@pytest.mark.xfail(reason="issue#4: template tries to set variable in outer scope")
+def test_checkboxes():
+    env = Environment()
+    template = env.from_string(
+"""
+{% from "checkboxes/macro.njk" import govukCheckboxes %}
+
+{{ govukCheckboxes({
+  "idPrefix": "nationality",
+  "name": "nationality",
+  "fieldset": {
+    "legend": {
+      "text": "What is your nationality?"
+    }
+  },
+  "hint": {
+    "text": "If you have dual nationality, select all options that are relevant to you."
+  },
+  "items": [
+    {
+      "value": "british",
+      "text": "British"
+    },
+    {
+      "value": "irish",
+      "text": "Irish"
+    },
+    {
+      "value": "other",
+      "text": "Citizen of another country"
+    }
+  ]
+}) }}
+"""
+    )
+    assert (
+        pytest.helpers.normalise_whitespace(template.render())
+        ==
+        pytest.helpers.normalise_whitespace(
+"""
+<div class="govuk-form-group">
+
+  <fieldset class="govuk-fieldset" aria-describedby="nationality-hint">
+
+  <legend class="govuk-fieldset__legend">
+    What is your nationality?
+  </legend>
+
+  <span id="nationality-hint" class="govuk-hint">
+    If you have dual nationality, select all options that are relevant to you.
+  </span>
+
+  <div class="govuk-checkboxes">
+
+    <div class="govuk-checkboxes__item">
+      <input class="govuk-checkboxes__input" id="nationality-1" name="nationality" type="checkbox" value="british">
+      <label class="govuk-label govuk-checkboxes__label" for="nationality-1">
+        British
+      </label>
+    </div>
+
+    <div class="govuk-checkboxes__item">
+      <input class="govuk-checkboxes__input" id="nationality-2" name="nationality" type="checkbox" value="irish">
+      <label class="govuk-label govuk-checkboxes__label" for="nationality-2">
+        Irish
+      </label>
+    </div>
+
+    <div class="govuk-checkboxes__item">
+      <input class="govuk-checkboxes__input" id="nationality-3" name="nationality" type="checkbox" value="other">
+      <label class="govuk-label govuk-checkboxes__label" for="nationality-3">
+        Citizen of another country
+      </label>
+    </div>
+
+  </div>
+  </fieldset>
+
+</div>
+"""
+        )
+    )

--- a/tests/components/test_checkboxes.py
+++ b/tests/components/test_checkboxes.py
@@ -4,7 +4,6 @@ import pytest
 from govuk_frontend.templates import Environment
 
 
-@pytest.mark.xfail(reason="issue#4: template tries to set variable in outer scope")
 def test_checkboxes():
     env = Environment()
     template = env.from_string(
@@ -306,7 +305,6 @@ def test_checkboxes_with_disabled_item(env):
     )
 
 
-@pytest.mark.xfail(reason="issue#4: template tries to set variable in outer scope")
 def test_checkboxes_with_legend_as_page_heading(env):
     template = env.from_string(
 """
@@ -392,7 +390,6 @@ def test_checkboxes_with_legend_as_page_heading(env):
     )
 
 
-@pytest.mark.xfail(reason="issue#4: template tries to set variable in outer scope")
 def test_checkboxes_with_a_medium_legend(env):
     template = env.from_string(
 """
@@ -544,7 +541,6 @@ def test_checkboxes_without_fieldset(env):
     )
 
 
-@pytest.mark.xfail(reason="issue#4: template tries to set variable in outer scope")
 def test_checkboxes_with_all_fieldset_attributes(env):
     template = env.from_string(
 """
@@ -639,7 +635,6 @@ def test_checkboxes_with_all_fieldset_attributes(env):
     )
 
 
-@pytest.mark.xfail(reason="issue#4: template tries to set variable in outer scope")
 def test_checkboxes_with_error_message(env):
     template = env.from_string(
 """

--- a/tests/components/test_date_input.py
+++ b/tests/components/test_date_input.py
@@ -2,7 +2,6 @@
 import pytest
 
 
-@pytest.mark.xfail(reason="issue #4: template tries to set variable in outer scope")
 def test_date_input(env):
     template = env.from_string(
 """
@@ -92,7 +91,6 @@ def test_date_input(env):
     )
 
 
-@pytest.mark.xfail(reason="issue #4: template tries to set variable in outer scope")
 def test_date_input_with_errors(env):
     template = env.from_string(
 """
@@ -189,7 +187,6 @@ def test_date_input_with_errors(env):
     )
 
 
-@pytest.mark.xfail(reason="issue #4: template tries to set variable in outer scope")
 def test_date_input_with_error_on_day_input(env):
     template = env.from_string(
 """
@@ -287,7 +284,6 @@ def test_date_input_with_error_on_day_input(env):
     )
 
 
-@pytest.mark.xfail(reason="issue #4: template tries to set variable in outer scope")
 def test_date_input_with_error_on_month_input(env):
     template = env.from_string(
 """
@@ -385,7 +381,6 @@ def test_date_input_with_error_on_month_input(env):
     )
 
 
-@pytest.mark.xfail(reason="issue #4: template tries to set variable in outer scope")
 def test_date_input_with_error_on_year_input(env):
     template = env.from_string(
 """

--- a/tests/components/test_date_input.py
+++ b/tests/components/test_date_input.py
@@ -1,0 +1,560 @@
+
+import pytest
+
+
+@pytest.mark.xfail(reason="issue #4: template tries to set variable in outer scope")
+def test_date_input(env):
+    template = env.from_string(
+"""
+{% from "date-input/macro.njk" import govukDateInput %}
+
+{{ govukDateInput({
+  "id": "dob",
+  "namePrefix": "dob",
+  "fieldset": {
+    "legend": {
+      "text": "What is your date of birth?"
+    }
+  },
+  "hint": {
+    "text": "For example, 31 3 1980"
+  },
+  "items": [
+    {
+      "name": "day",
+      "classes": "govuk-input--width-2"
+    },
+    {
+      "name": "month",
+      "classes": "govuk-input--width-2"
+    },
+    {
+      "name": "year",
+      "classes": "govuk-input--width-4"
+    }
+  ]
+}) }}
+"""
+    )
+    assert (
+        pytest.helpers.normalise_whitespace(template.render())
+        ==
+        pytest.helpers.normalise_whitespace(
+"""<div class="govuk-form-group">
+<fieldset class="govuk-fieldset" aria-describedby="dob-hint" role="group">
+
+  <legend class="govuk-fieldset__legend">
+    What is your date of birth?
+  </legend>
+
+  <span id="dob-hint" class="govuk-hint">
+    For example, 31 3 1980
+  </span>
+
+  <div class="govuk-date-input" id="dob">
+
+    <div class="govuk-date-input__item">
+      <div class="govuk-form-group">
+        <label class="govuk-label govuk-date-input__label" for="dob-day">
+          Day
+        </label>
+
+        <input class="govuk-input govuk-date-input__input govuk-input--width-2" id="dob-day" name="dob-day" type="number" pattern="[0-9]*">
+      </div>
+    </div>
+
+    <div class="govuk-date-input__item">
+      <div class="govuk-form-group">
+        <label class="govuk-label govuk-date-input__label" for="dob-month">
+          Month
+        </label>
+
+        <input class="govuk-input govuk-date-input__input govuk-input--width-2" id="dob-month" name="dob-month" type="number" pattern="[0-9]*">
+      </div>
+    </div>
+
+    <div class="govuk-date-input__item">
+      <div class="govuk-form-group">
+        <label class="govuk-label govuk-date-input__label" for="dob-year">
+          Year
+        </label>
+
+        <input class="govuk-input govuk-date-input__input govuk-input--width-4" id="dob-year" name="dob-year" type="number" pattern="[0-9]*">
+      </div>
+    </div>
+
+  </div>
+  </fieldset>
+
+</div>
+"""
+        )
+    )
+
+
+@pytest.mark.xfail(reason="issue #4: template tries to set variable in outer scope")
+def test_date_input_with_errors(env):
+    template = env.from_string(
+"""
+{% from "date-input/macro.njk" import govukDateInput %}
+
+{{ govukDateInput({
+  "id": "dob-errors",
+  "fieldset": {
+    "legend": {
+      "text": "What is your date of birth?"
+    }
+  },
+  "hint": {
+    "text": "For example, 31 3 1980"
+  },
+  "errorMessage": {
+    "text": "Error message goes here"
+  },
+  "items": [
+    {
+      "name": "day",
+      "classes": "govuk-input--width-2 govuk-input--error"
+    },
+    {
+      "name": "month",
+      "classes": "govuk-input--width-2 govuk-input--error"
+    },
+    {
+      "name": "year",
+      "classes": "govuk-input--width-4 govuk-input--error"
+    }
+  ]
+}) }}
+"""
+    )
+    assert (
+        pytest.helpers.normalise_whitespace(template.render())
+        ==
+        pytest.helpers.normalise_whitespace(
+"""
+<div class="govuk-form-group govuk-form-group--error">
+<fieldset class="govuk-fieldset" aria-describedby="dob-errors-hint dob-errors-error" role="group">
+
+  <legend class="govuk-fieldset__legend">
+    What is your date of birth?
+  </legend>
+
+  <span id="dob-errors-hint" class="govuk-hint">
+    For example, 31 3 1980
+  </span>
+
+  <span id="dob-errors-error" class="govuk-error-message">
+    Error message goes here
+  </span>
+
+  <div class="govuk-date-input" id="dob-errors">
+
+    <div class="govuk-date-input__item">
+      <div class="govuk-form-group">
+        <label class="govuk-label govuk-date-input__label" for="dob-errors-day">
+          Day
+        </label>
+
+        <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input--error" id="dob-errors-day" name="day" type="number" pattern="[0-9]*">
+      </div>
+    </div>
+
+    <div class="govuk-date-input__item">
+      <div class="govuk-form-group">
+        <label class="govuk-label govuk-date-input__label" for="dob-errors-month">
+          Month
+        </label>
+
+        <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input--error" id="dob-errors-month" name="month" type="number" pattern="[0-9]*">
+      </div>
+    </div>
+
+    <div class="govuk-date-input__item">
+      <div class="govuk-form-group">
+        <label class="govuk-label govuk-date-input__label" for="dob-errors-year">
+          Year
+        </label>
+
+        <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input--error" id="dob-errors-year" name="year" type="number" pattern="[0-9]*">
+      </div>
+    </div>
+
+  </div>
+  </fieldset>
+
+</div>
+"""
+        )
+    )
+
+
+@pytest.mark.xfail(reason="issue #4: template tries to set variable in outer scope")
+def test_date_input_with_error_on_day_input(env):
+    template = env.from_string(
+"""
+{% from "date-input/macro.njk" import govukDateInput %}
+
+{{ govukDateInput({
+  "id": "dob-day-error",
+  "namePrefix": "dob-day-error",
+  "fieldset": {
+    "legend": {
+      "text": "What is your date of birth?"
+    }
+  },
+  "hint": {
+    "text": "For example, 31 3 1980"
+  },
+  "errorMessage": {
+    "text": "Error message goes here"
+  },
+  "items": [
+    {
+      "name": "day",
+      "classes": "govuk-input--width-2 govuk-input--error"
+    },
+    {
+      "name": "month",
+      "classes": "govuk-input--width-2"
+    },
+    {
+      "name": "year",
+      "classes": "govuk-input--width-4"
+    }
+  ]
+}) }}
+"""
+    )
+    assert (
+        pytest.helpers.normalise_whitespace(template.render())
+        ==
+        pytest.helpers.normalise_whitespace(
+"""
+<div class="govuk-form-group govuk-form-group--error">
+<fieldset class="govuk-fieldset" aria-describedby="dob-day-error-hint dob-day-error-error" role="group">
+
+  <legend class="govuk-fieldset__legend">
+    What is your date of birth?
+  </legend>
+
+  <span id="dob-day-error-hint" class="govuk-hint">
+    For example, 31 3 1980
+  </span>
+
+  <span id="dob-day-error-error" class="govuk-error-message">
+    Error message goes here
+  </span>
+
+  <div class="govuk-date-input" id="dob-day-error">
+
+    <div class="govuk-date-input__item">
+      <div class="govuk-form-group">
+        <label class="govuk-label govuk-date-input__label" for="dob-day-error-day">
+          Day
+        </label>
+
+        <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input--error" id="dob-day-error-day" name="dob-day-error-day" type="number" pattern="[0-9]*">
+      </div>
+    </div>
+
+    <div class="govuk-date-input__item">
+      <div class="govuk-form-group">
+        <label class="govuk-label govuk-date-input__label" for="dob-day-error-month">
+          Month
+        </label>
+
+        <input class="govuk-input govuk-date-input__input govuk-input--width-2" id="dob-day-error-month" name="dob-day-error-month" type="number" pattern="[0-9]*">
+      </div>
+    </div>
+
+    <div class="govuk-date-input__item">
+      <div class="govuk-form-group">
+        <label class="govuk-label govuk-date-input__label" for="dob-day-error-year">
+          Year
+        </label>
+
+        <input class="govuk-input govuk-date-input__input govuk-input--width-4" id="dob-day-error-year" name="dob-day-error-year" type="number" pattern="[0-9]*">
+      </div>
+    </div>
+
+  </div>
+  </fieldset>
+
+</div>
+"""
+        )
+    )
+
+
+@pytest.mark.xfail(reason="issue #4: template tries to set variable in outer scope")
+def test_date_input_with_error_on_month_input(env):
+    template = env.from_string(
+"""
+{% from "date-input/macro.njk" import govukDateInput %}
+
+{{ govukDateInput({
+  "id": "dob-month-error",
+  "namePrefix": "dob-month-error",
+  "fieldset": {
+    "legend": {
+      "text": "What is your date of birth?"
+    }
+  },
+  "hint": {
+    "text": "For example, 31 3 1980"
+  },
+  "errorMessage": {
+    "text": "Error message goes here"
+  },
+  "items": [
+    {
+      "name": "day",
+      "classes": "govuk-input--width-2"
+    },
+    {
+      "name": "month",
+      "classes": "govuk-input--width-2 govuk-input--error"
+    },
+    {
+      "name": "year",
+      "classes": "govuk-input--width-4"
+    }
+  ]
+}) }}
+"""
+    )
+    assert (
+        pytest.helpers.normalise_whitespace(template.render())
+        ==
+        pytest.helpers.normalise_whitespace(
+"""
+<div class="govuk-form-group govuk-form-group--error">
+<fieldset class="govuk-fieldset" aria-describedby="dob-month-error-hint dob-month-error-error" role="group">
+
+  <legend class="govuk-fieldset__legend">
+    What is your date of birth?
+  </legend>
+
+  <span id="dob-month-error-hint" class="govuk-hint">
+    For example, 31 3 1980
+  </span>
+
+  <span id="dob-month-error-error" class="govuk-error-message">
+    Error message goes here
+  </span>
+
+  <div class="govuk-date-input" id="dob-month-error">
+
+    <div class="govuk-date-input__item">
+      <div class="govuk-form-group">
+        <label class="govuk-label govuk-date-input__label" for="dob-month-error-day">
+          Day
+        </label>
+
+        <input class="govuk-input govuk-date-input__input govuk-input--width-2" id="dob-month-error-day" name="dob-month-error-day" type="number" pattern="[0-9]*">
+      </div>
+    </div>
+
+    <div class="govuk-date-input__item">
+      <div class="govuk-form-group">
+        <label class="govuk-label govuk-date-input__label" for="dob-month-error-month">
+          Month
+        </label>
+
+        <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input--error" id="dob-month-error-month" name="dob-month-error-month" type="number" pattern="[0-9]*">
+      </div>
+    </div>
+
+    <div class="govuk-date-input__item">
+      <div class="govuk-form-group">
+        <label class="govuk-label govuk-date-input__label" for="dob-month-error-year">
+          Year
+        </label>
+
+        <input class="govuk-input govuk-date-input__input govuk-input--width-4" id="dob-month-error-year" name="dob-month-error-year" type="number" pattern="[0-9]*">
+      </div>
+    </div>
+
+  </div>
+  </fieldset>
+
+</div>
+"""
+        )
+    )
+
+
+@pytest.mark.xfail(reason="issue #4: template tries to set variable in outer scope")
+def test_date_input_with_error_on_year_input(env):
+    template = env.from_string(
+"""
+{% from "date-input/macro.njk" import govukDateInput %}
+
+{{ govukDateInput({
+  "id": "dob-year-error",
+  "namePrefix": "dob-year-error",
+  "fieldset": {
+    "legend": {
+      "text": "What is your date of birth?"
+    }
+  },
+  "hint": {
+    "text": "For example, 31 3 1980"
+  },
+  "errorMessage": {
+    "text": "Error message goes here"
+  },
+  "items": [
+    {
+      "name": "day",
+      "classes": "govuk-input--width-2"
+    },
+    {
+      "name": "month",
+      "classes": "govuk-input--width-2"
+    },
+    {
+      "name": "year",
+      "classes": "govuk-input--width-4 govuk-input--error"
+    }
+  ]
+}) }}
+"""
+    )
+    assert (
+        pytest.helpers.normalise_whitespace(template.render())
+        ==
+        pytest.helpers.normalise_whitespace(
+"""
+<div class="govuk-form-group govuk-form-group--error">
+<fieldset class="govuk-fieldset" aria-describedby="dob-year-error-hint dob-year-error-error" role="group">
+
+  <legend class="govuk-fieldset__legend">
+    What is your date of birth?
+  </legend>
+
+  <span id="dob-year-error-hint" class="govuk-hint">
+    For example, 31 3 1980
+  </span>
+
+  <span id="dob-year-error-error" class="govuk-error-message">
+    Error message goes here
+  </span>
+
+  <div class="govuk-date-input" id="dob-year-error">
+
+    <div class="govuk-date-input__item">
+      <div class="govuk-form-group">
+        <label class="govuk-label govuk-date-input__label" for="dob-year-error-day">
+          Day
+        </label>
+
+        <input class="govuk-input govuk-date-input__input govuk-input--width-2" id="dob-year-error-day" name="dob-year-error-day" type="number" pattern="[0-9]*">
+      </div>
+    </div>
+
+    <div class="govuk-date-input__item">
+      <div class="govuk-form-group">
+        <label class="govuk-label govuk-date-input__label" for="dob-year-error-month">
+          Month
+        </label>
+
+        <input class="govuk-input govuk-date-input__input govuk-input--width-2" id="dob-year-error-month" name="dob-year-error-month" type="number" pattern="[0-9]*">
+      </div>
+    </div>
+
+    <div class="govuk-date-input__item">
+      <div class="govuk-form-group">
+        <label class="govuk-label govuk-date-input__label" for="dob-year-error-year">
+          Year
+        </label>
+
+        <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input--error" id="dob-year-error-year" name="dob-year-error-year" type="number" pattern="[0-9]*">
+      </div>
+    </div>
+
+  </div>
+  </fieldset>
+
+</div>
+"""
+        )
+    )
+
+
+@pytest.mark.xfail(reason="attempting to access params.items")
+def test_date_input_with_default_items(env):
+    template = env.from_string(
+"""
+{% from "date-input/macro.njk" import govukDateInput %}
+
+{{ govukDateInput({
+  "id": "dob",
+  "namePrefix": "dob",
+  "fieldset": {
+    "legend": {
+      "text": "What is your date of birth?"
+    }
+  },
+  "hint": {
+    "text": "For example, 31 3 1980"
+  }
+}) }}
+"""
+    )
+    assert (
+        pytest.helpers.normalise_whitespace(template.render())
+        ==
+        pytest.helpers.normalise_whitespace(
+"""
+<div class="govuk-form-group">
+<fieldset class="govuk-fieldset" aria-describedby="dob-hint" role="group">
+
+  <legend class="govuk-fieldset__legend">
+    What is your date of birth?
+  </legend>
+
+  <span id="dob-hint" class="govuk-hint">
+    For example, 31 3 1980
+  </span>
+
+  <div class="govuk-date-input" id="dob">
+
+    <div class="govuk-date-input__item">
+      <div class="govuk-form-group">
+        <label class="govuk-label govuk-date-input__label" for="dob-day">
+          Day
+        </label>
+
+        <input class="govuk-input govuk-date-input__input govuk-input--width-2" id="dob-day" name="dob-day" type="number" pattern="[0-9]*">
+      </div>
+    </div>
+
+    <div class="govuk-date-input__item">
+      <div class="govuk-form-group">
+        <label class="govuk-label govuk-date-input__label" for="dob-month">
+          Month
+        </label>
+
+        <input class="govuk-input govuk-date-input__input govuk-input--width-2" id="dob-month" name="dob-month" type="number" pattern="[0-9]*">
+      </div>
+    </div>
+
+    <div class="govuk-date-input__item">
+      <div class="govuk-form-group">
+        <label class="govuk-label govuk-date-input__label" for="dob-year">
+          Year
+        </label>
+
+        <input class="govuk-input govuk-date-input__input govuk-input--width-4" id="dob-year" name="dob-year" type="number" pattern="[0-9]*">
+      </div>
+    </div>
+
+  </div>
+  </fieldset>
+
+</div>
+"""
+        )
+    )

--- a/tests/components/test_details.py
+++ b/tests/components/test_details.py
@@ -1,0 +1,76 @@
+
+import pytest
+
+from govuk_frontend.templates import Environment
+
+
+def test_details():
+    env = Environment()
+    template = env.from_string(
+"""
+{% from "details/macro.njk" import govukDetails %}
+
+{{ govukDetails({
+  "summaryText": "Help with nationality",
+  "text": "We need to know your nationality so we can work out which elections you’re entitled to vote in. If you can’t provide your nationality, you’ll have to send copies of identity documents through the post."
+}) }}
+"""
+    )
+    assert (
+        pytest.helpers.normalise_whitespace(template.render())
+        ==
+        pytest.helpers.normalise_whitespace(
+            """
+            <details class="govuk-details">
+              <summary class="govuk-details__summary">
+                <span class="govuk-details__summary-text">
+                  Help with nationality
+                </span>
+              </summary>
+              <div class="govuk-details__text">
+                We need to know your nationality so we can work out which elections you’re entitled to vote in. If you can’t provide your nationality, you’ll have to send copies of identity documents through the post.
+              </div>
+            </details>
+            """
+        )
+    )
+
+
+def test_details_with_html():
+    env = Environment()
+    template = env.from_string(
+"""
+{% from "details/macro.njk" import govukDetails %}
+
+{{ govukDetails({
+  "summaryText": "Where to find your National Insurance Number",
+  "html": "Your National Insurance number can be found on\n<ul>\n  <li>your National Insurance card</li>\n  <li>your payslip</li>\n  <li>P60</li>\n  <li>benefits information</li>\n  <li>tax return</li>\n</ul>\n"
+}) }}
+"""
+    )
+    assert (
+        pytest.helpers.normalise_whitespace(template.render())
+        ==
+        pytest.helpers.normalise_whitespace(
+            """
+            <details class="govuk-details">
+              <summary class="govuk-details__summary">
+                <span class="govuk-details__summary-text">
+                  Where to find your National Insurance Number
+                </span>
+              </summary>
+              <div class="govuk-details__text">
+                Your National Insurance number can be found on
+            <ul>
+              <li>your National Insurance card</li>
+              <li>your payslip</li>
+              <li>P60</li>
+              <li>benefits information</li>
+              <li>tax return</li>
+            </ul>
+
+              </div>
+            </details>
+            """
+        )
+    )

--- a/tests/components/test_error_message.py
+++ b/tests/components/test_error_message.py
@@ -1,0 +1,25 @@
+
+import pytest
+
+
+def test_error_message(env):
+    template = env.from_string(
+"""
+{% from "error-message/macro.njk" import govukErrorMessage %}
+
+{{ govukErrorMessage({
+  "text": "Error message about full name goes here"
+}) }}
+"""
+    )
+    assert (
+        pytest.helpers.normalise_whitespace(template.render())
+        ==
+        pytest.helpers.normalise_whitespace(
+"""
+<span class="govuk-error-message">
+  Error message about full name goes here
+</span>
+"""
+        )
+    )

--- a/tests/components/test_error_summary.py
+++ b/tests/components/test_error_summary.py
@@ -1,0 +1,61 @@
+
+import pytest
+
+
+def test_error_summary(env):
+    template = env.from_string(
+"""
+{% from "error-summary/macro.njk" import govukErrorSummary %}
+
+{{ govukErrorSummary({
+  "titleText": "Message to alert the user to a problem goes here",
+  "descriptionText": "Optional description of the errors and how to correct them",
+  "classes": "optional-extra-class",
+  "errorList": [
+    {
+      "text": "Descriptive link to the question with an error",
+      "href": "#example-error-1"
+    },
+    {
+      "text": "Descriptive link to the question with an error",
+      "href": "#example-error-1"
+    }
+  ]
+}) }}
+"""
+    )
+    assert (
+        pytest.helpers.normalise_whitespace(template.render())
+        ==
+        pytest.helpers.normalise_whitespace(
+"""
+<div class="govuk-error-summary optional-extra-class" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="error-summary">
+  <h2 class="govuk-error-summary__title" id="error-summary-title">
+    Message to alert the user to a problem goes here
+  </h2>
+  <div class="govuk-error-summary__body">
+
+    <p>
+      Optional description of the errors and how to correct them
+    </p>
+
+    <ul class="govuk-list govuk-error-summary__list">
+
+      <li>
+
+        <a href="#example-error-1">Descriptive link to the question with an error</a>
+
+      </li>
+
+      <li>
+
+        <a href="#example-error-1">Descriptive link to the question with an error</a>
+
+      </li>
+
+    </ul>
+  </div>
+</div>
+"""
+        )
+    )

--- a/tests/components/test_fieldset.py
+++ b/tests/components/test_fieldset.py
@@ -1,0 +1,29 @@
+
+from govuk_frontend.templates import Environment
+
+
+def test_fieldset():
+    env = Environment()
+    template = env.from_string(
+"""{% from "components/fieldset/macro.njk" import govukFieldset %}
+
+{{ govukFieldset({
+  "legend": {
+    "text": "What is your address?"
+  }
+}) }}
+"""
+    )
+    assert (
+        template.render()
+        ==
+"""
+
+<fieldset class="govuk-fieldset">
+  
+  <legend class="govuk-fieldset__legend">
+    What is your address?
+  </legend>
+  
+</fieldset>"""
+    )

--- a/tests/components/test_fieldset.py
+++ b/tests/components/test_fieldset.py
@@ -1,4 +1,6 @@
 
+import pytest
+
 from govuk_frontend.templates import Environment
 
 
@@ -26,4 +28,47 @@ def test_fieldset():
   </legend>
   
 </fieldset>"""
+    )
+
+
+def test_fieldset_with_block():
+    env = Environment()
+    template = env.from_string(
+"""
+{% from "components/fieldset/macro.njk" import govukFieldset %}
+
+{% call govukFieldset({
+  "legend": {
+    "text": "What is your address?"
+  }
+}) %}
+  <div class="govuk-form-group">
+    <label class="govuk-label" for="address-line-1">
+      Building and street <span class="govuk-visually-hidden">line 1 of 2</span>
+    </label>
+    <input class="govuk-input" id="address-line-1" name="address-line-1" type="text">
+  </div>
+{% endcall %}
+"""
+    )
+    assert (
+        pytest.helpers.normalise_whitespace(template.render())
+        ==
+        pytest.helpers.normalise_whitespace(
+"""
+<fieldset class="govuk-fieldset">
+
+  <legend class="govuk-fieldset__legend">
+    What is your address?
+  </legend>
+
+  <div class="govuk-form-group">
+    <label class="govuk-label" for="address-line-1">
+      Building and street <span class="govuk-visually-hidden">line 1 of 2</span>
+    </label>
+    <input class="govuk-input" id="address-line-1" name="address-line-1" type="text">
+  </div>
+</fieldset>
+"""
+        )
     )

--- a/tests/components/test_file_upload.py
+++ b/tests/components/test_file_upload.py
@@ -1,0 +1,187 @@
+
+import pytest
+
+
+def test_file_upload(env):
+    template = env.from_string(
+"""
+{% from "file-upload/macro.njk" import govukFileUpload %}
+
+{{ govukFileUpload({
+  "id": "file-upload-1",
+  "name": "file-upload-1",
+  "label": {
+    "text": "Upload a file"
+  }
+}) }}
+"""
+    )
+    assert (
+        pytest.helpers.normalise_whitespace(template.render())
+        ==
+        pytest.helpers.normalise_whitespace(
+"""
+<div class="govuk-form-group">
+  <label class="govuk-label" for="file-upload-1">
+    Upload a file
+  </label>
+
+  <input class="govuk-file-upload" id="file-upload-1" name="file-upload-1" type="file">
+</div>
+"""
+        )
+    )
+
+
+def test_file_upload_with_hint_text(env):
+    template = env.from_string(
+"""
+{% from "file-upload/macro.njk" import govukFileUpload %}
+
+{{ govukFileUpload({
+  "id": "file-upload-2",
+  "name": "file-upload-2",
+  "label": {
+    "text": "Upload your photo"
+  },
+  "hint": {
+    "text": "Your photo may be in your Pictures, Photos, Downloads or Desktop folder. Or in an app like iPhoto."
+  }
+}) }}
+"""
+    )
+    assert (
+        pytest.helpers.normalise_whitespace(template.render())
+        ==
+        pytest.helpers.normalise_whitespace(
+"""
+<div class="govuk-form-group">
+  <label class="govuk-label" for="file-upload-2">
+    Upload your photo
+  </label>
+
+  <span id="file-upload-2-hint" class="govuk-hint">
+    Your photo may be in your Pictures, Photos, Downloads or Desktop folder. Or in an app like iPhoto.
+  </span>
+
+  <input class="govuk-file-upload" id="file-upload-2" name="file-upload-2" type="file" aria-describedby="file-upload-2-hint">
+</div>
+"""
+        )
+    )
+
+
+def test_file_upload_with_error_message(env):
+    template = env.from_string(
+"""
+{% from "file-upload/macro.njk" import govukFileUpload %}
+
+{{ govukFileUpload({
+  "id": "file-upload-3",
+  "name": "file-upload-3",
+  "label": {
+    "text": "Upload a file"
+  },
+  "hint": {
+    "text": "Your photo may be in your Pictures, Photos, Downloads or Desktop folder. Or in an app like iPhoto."
+  },
+  "errorMessage": {
+    "text": "Error message goes here"
+  }
+}) }}
+"""
+    )
+    assert (
+        pytest.helpers.normalise_whitespace(template.render())
+        ==
+        pytest.helpers.normalise_whitespace(
+"""
+<div class="govuk-form-group govuk-form-group--error">
+  <label class="govuk-label" for="file-upload-3">
+    Upload a file
+  </label>
+
+  <span id="file-upload-3-hint" class="govuk-hint">
+    Your photo may be in your Pictures, Photos, Downloads or Desktop folder. Or in an app like iPhoto.
+  </span>
+
+  <span id="file-upload-3-error" class="govuk-error-message">
+    Error message goes here
+  </span>
+
+  <input class="govuk-file-upload govuk-file-upload--error" id="file-upload-3" name="file-upload-3" type="file" aria-describedby="file-upload-3-hint file-upload-3-error">
+</div>
+"""
+        )
+    )
+
+
+def test_file_upload_with_value_and_attributes(env):
+    template = env.from_string(
+r"""
+{% from "file-upload/macro.njk" import govukFileUpload %}
+
+{{ govukFileUpload({
+  "id": "file-upload-4",
+  "name": "file-upload-4",
+  "value": "C:\\fakepath\\myphoto.jpg",
+  "label": {
+    "text": "Upload a photo"
+  },
+  "attributes": {
+    "accept": ".jpg, .jpeg, .png"
+  }
+}) }}
+"""
+    )
+    assert (
+        pytest.helpers.normalise_whitespace(template.render())
+        ==
+        pytest.helpers.normalise_whitespace(
+r"""
+<div class="govuk-form-group">
+  <label class="govuk-label" for="file-upload-4">
+    Upload a photo
+  </label>
+
+  <input class="govuk-file-upload" id="file-upload-4" name="file-upload-4" type="file" value="C:\fakepath\myphoto.jpg" accept=".jpg, .jpeg, .png">
+</div>
+"""
+        )
+    )
+
+
+@pytest.mark.xfail(reason="autoescape required, HTML entities are being escaped")
+def test_file_upload_with_label_as_page_heading(env):
+    template = env.from_string(
+"""
+{% from "file-upload/macro.njk" import govukFileUpload %}
+
+{{ govukFileUpload({
+  "id": "file-upload-1",
+  "name": "file-upload-1",
+  "label": {
+    "text": "Upload a file",
+    "isPageHeading": true
+  }
+}) }}
+"""
+    )
+    assert (
+        pytest.helpers.normalise_whitespace(template.render())
+        ==
+        pytest.helpers.normalise_whitespace(
+"""
+<div class="govuk-form-group">
+  <h1 class="govuk-label-wrapper">
+    <label class="govuk-label" for="file-upload-1">
+      Upload a file
+    </label>
+
+  </h1>
+
+  <input class="govuk-file-upload" id="file-upload-1" name="file-upload-1" type="file">
+</div>
+"""
+        )
+    )

--- a/tests/components/test_footer.py
+++ b/tests/components/test_footer.py
@@ -1,0 +1,58 @@
+
+import pytest
+
+
+def test_footer(env):
+    template = env.from_string(
+"""
+{% from "footer/macro.njk" import govukFooter %}
+
+{{ govukFooter({}) }}
+"""
+    )
+    assert (
+        pytest.helpers.normalise_whitespace(template.render())
+        ==
+        pytest.helpers.normalise_whitespace(
+"""
+<footer class="govuk-footer " role="contentinfo">
+  <div class="govuk-width-container ">
+
+    <div class="govuk-footer__meta">
+      <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
+
+        <svg
+          role="presentation"
+          focusable="false"
+          class="govuk-footer__licence-logo"
+          xmlns="http://www.w3.org/2000/svg"
+          viewbox="0 0 483.2 195.7"
+          height="17"
+          width="41"
+        >
+          <path
+            fill="currentColor"
+            d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145"
+          />
+        </svg>
+        <span class="govuk-footer__licence-description">
+          All content is available under the
+          <a
+            class="govuk-footer__link"
+            href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+            rel="license"
+          >Open Government Licence v3.0</a>, except where otherwise stated
+        </span>
+      </div>
+      <div class="govuk-footer__meta-item">
+        <a
+          class="govuk-footer__link govuk-footer__copyright-logo"
+          href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/"
+        >© Crown copyright</a>
+      </div>
+    </div>
+  </div>
+</footer>
+"""
+        )
+    )

--- a/tests/components/test_header.py
+++ b/tests/components/test_header.py
@@ -227,7 +227,6 @@ def test_header_with_service_name_and_navigation(env):
     )
 
 
-@pytest.mark.xfail(reason="inline if-expression not targeted by regex")
 def test_header_with_service_name_and_navigation_and_autoescape(env):
     from govuk_frontend.templates import Environment
     env = Environment(autoescape=True)

--- a/tests/components/test_header.py
+++ b/tests/components/test_header.py
@@ -1,0 +1,227 @@
+
+import pytest
+
+
+def test_header(env):
+    template = env.from_string(
+"""
+{% from "header/macro.njk" import govukHeader %}
+
+{{ govukHeader({}) }}
+"""
+    )
+    assert (
+        pytest.helpers.normalise_whitespace(template.render())
+        ==
+        pytest.helpers.normalise_whitespace(
+"""
+<header class="govuk-header " role="banner" data-module="header">
+  <div class="govuk-header__container govuk-width-container">
+
+    <div class="govuk-header__logo">
+      <a href="/" class="govuk-header__link govuk-header__link--homepage">
+        <span class="govuk-header__logotype">
+
+          <svg
+            role="presentation"
+            focusable="false"
+            class="govuk-header__logotype-crown"
+            xmlns="http://www.w3.org/2000/svg"
+            viewbox="0 0 132 97"
+            height="32"
+            width="36"
+          >
+            <path
+              fill="currentColor" fill-rule="evenodd"
+              d="M25 30.2c3.5 1.5 7.7-.2 9.1-3.7 1.5-3.6-.2-7.8-3.9-9.2-3.6-1.4-7.6.3-9.1 3.9-1.4 3.5.3 7.5 3.9 9zM9 39.5c3.6 1.5 7.8-.2 9.2-3.7 1.5-3.6-.2-7.8-3.9-9.1-3.6-1.5-7.6.2-9.1 3.8-1.4 3.5.3 7.5 3.8 9zM4.4 57.2c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.5-1.5-7.6.3-9.1 3.8-1.4 3.5.3 7.6 3.9 9.1zm38.3-21.4c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.6-1.5-7.6.3-9.1 3.8-1.3 3.6.4 7.7 3.9 9.1zm64.4-5.6c-3.6 1.5-7.8-.2-9.1-3.7-1.5-3.6.2-7.8 3.8-9.2 3.6-1.4 7.7.3 9.2 3.9 1.3 3.5-.4 7.5-3.9 9zm15.9 9.3c-3.6 1.5-7.7-.2-9.1-3.7-1.5-3.6.2-7.8 3.7-9.1 3.6-1.5 7.7.2 9.2 3.8 1.5 3.5-.3 7.5-3.8 9zm4.7 17.7c-3.6 1.5-7.8-.2-9.2-3.8-1.5-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.3 3.5-.4 7.6-3.9 9.1zM89.3 35.8c-3.6 1.5-7.8-.2-9.2-3.8-1.4-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.4 3.6-.3 7.7-3.9 9.1zM69.7 17.7l8.9 4.7V9.3l-8.9 2.8c-.2-.3-.5-.6-.9-.9L72.4 0H59.6l3.5 11.2c-.3.3-.6.5-.9.9l-8.8-2.8v13.1l8.8-4.7c.3.3.6.7.9.9l-5 15.4v.1c-.2.8-.4 1.6-.4 2.4 0 4.1 3.1 7.5 7 8.1h.2c.3 0 .7.1 1 .1.4 0 .7 0 1-.1h.2c4-.6 7.1-4.1 7.1-8.1 0-.8-.1-1.7-.4-2.4V34l-5.1-15.4c.4-.2.7-.6 1-.9zM66 92.8c16.9 0 32.8 1.1 47.1 3.2 4-16.9 8.9-26.7 14-33.5l-9.6-3.4c1 4.9 1.1 7.2 0 10.2-1.5-1.4-3-4.3-4.2-8.7L108.6 76c2.8-2 5-3.2 7.5-3.3-4.4 9.4-10 11.9-13.6 11.2-4.3-.8-6.3-4.6-5.6-7.9 1-4.7 5.7-5.9 8-.5 4.3-8.7-3-11.4-7.6-8.8 7.1-7.2 7.9-13.5 2.1-21.1-8 6.1-8.1 12.3-4.5 20.8-4.7-5.4-12.1-2.5-9.5 6.2 3.4-5.2 7.9-2 7.2 3.1-.6 4.3-6.4 7.8-13.5 7.2-10.3-.9-10.9-8-11.2-13.8 2.5-.5 7.1 1.8 11 7.3L80.2 60c-4.1 4.4-8 5.3-12.3 5.4 1.4-4.4 8-11.6 8-11.6H55.5s6.4 7.2 7.9 11.6c-4.2-.1-8-1-12.3-5.4l1.4 16.4c3.9-5.5 8.5-7.7 10.9-7.3-.3 5.8-.9 12.8-11.1 13.8-7.2.6-12.9-2.9-13.5-7.2-.7-5 3.8-8.3 7.1-3.1 2.7-8.7-4.6-11.6-9.4-6.2 3.7-8.5 3.6-14.7-4.6-20.8-5.8 7.6-5 13.9 2.2 21.1-4.7-2.6-11.9.1-7.7 8.8 2.3-5.5 7.1-4.2 8.1.5.7 3.3-1.3 7.1-5.7 7.9-3.5.7-9-1.8-13.5-11.2 2.5.1 4.7 1.3 7.5 3.3l-4.7-15.4c-1.2 4.4-2.7 7.2-4.3 8.7-1.1-3-.9-5.3 0-10.2l-9.5 3.4c5 6.9 9.9 16.7 14 33.5 14.8-2.1 30.8-3.2 47.7-3.2z"
+            ></path>
+
+            <image src="/assets/images/govuk-logotype-crown.png" class="govuk-header__logotype-crown-fallback-image"></image>
+          </svg>
+          <span class="govuk-header__logotype-text">
+            GOV.UK
+          </span>
+        </span>
+
+      </a>
+    </div>
+
+  </div>
+</header>
+"""
+        )
+    )
+
+
+def test_header_with_service_name(env):
+    template = env.from_string(
+"""
+{% from "header/macro.njk" import govukHeader %}
+
+{{ govukHeader({
+  "serviceName": "Service Name",
+  "serviceUrl": "/components/header"
+}) }}
+"""
+    )
+    assert (
+        pytest.helpers.normalise_whitespace(template.render())
+        ==
+        pytest.helpers.normalise_whitespace(
+"""
+<header class="govuk-header " role="banner" data-module="header">
+  <div class="govuk-header__container govuk-width-container">
+
+    <div class="govuk-header__logo">
+      <a href="/" class="govuk-header__link govuk-header__link--homepage">
+        <span class="govuk-header__logotype">
+
+          <svg
+            role="presentation"
+            focusable="false"
+            class="govuk-header__logotype-crown"
+            xmlns="http://www.w3.org/2000/svg"
+            viewbox="0 0 132 97"
+            height="32"
+            width="36"
+          >
+            <path
+              fill="currentColor" fill-rule="evenodd"
+              d="M25 30.2c3.5 1.5 7.7-.2 9.1-3.7 1.5-3.6-.2-7.8-3.9-9.2-3.6-1.4-7.6.3-9.1 3.9-1.4 3.5.3 7.5 3.9 9zM9 39.5c3.6 1.5 7.8-.2 9.2-3.7 1.5-3.6-.2-7.8-3.9-9.1-3.6-1.5-7.6.2-9.1 3.8-1.4 3.5.3 7.5 3.8 9zM4.4 57.2c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.5-1.5-7.6.3-9.1 3.8-1.4 3.5.3 7.6 3.9 9.1zm38.3-21.4c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.6-1.5-7.6.3-9.1 3.8-1.3 3.6.4 7.7 3.9 9.1zm64.4-5.6c-3.6 1.5-7.8-.2-9.1-3.7-1.5-3.6.2-7.8 3.8-9.2 3.6-1.4 7.7.3 9.2 3.9 1.3 3.5-.4 7.5-3.9 9zm15.9 9.3c-3.6 1.5-7.7-.2-9.1-3.7-1.5-3.6.2-7.8 3.7-9.1 3.6-1.5 7.7.2 9.2 3.8 1.5 3.5-.3 7.5-3.8 9zm4.7 17.7c-3.6 1.5-7.8-.2-9.2-3.8-1.5-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.3 3.5-.4 7.6-3.9 9.1zM89.3 35.8c-3.6 1.5-7.8-.2-9.2-3.8-1.4-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.4 3.6-.3 7.7-3.9 9.1zM69.7 17.7l8.9 4.7V9.3l-8.9 2.8c-.2-.3-.5-.6-.9-.9L72.4 0H59.6l3.5 11.2c-.3.3-.6.5-.9.9l-8.8-2.8v13.1l8.8-4.7c.3.3.6.7.9.9l-5 15.4v.1c-.2.8-.4 1.6-.4 2.4 0 4.1 3.1 7.5 7 8.1h.2c.3 0 .7.1 1 .1.4 0 .7 0 1-.1h.2c4-.6 7.1-4.1 7.1-8.1 0-.8-.1-1.7-.4-2.4V34l-5.1-15.4c.4-.2.7-.6 1-.9zM66 92.8c16.9 0 32.8 1.1 47.1 3.2 4-16.9 8.9-26.7 14-33.5l-9.6-3.4c1 4.9 1.1 7.2 0 10.2-1.5-1.4-3-4.3-4.2-8.7L108.6 76c2.8-2 5-3.2 7.5-3.3-4.4 9.4-10 11.9-13.6 11.2-4.3-.8-6.3-4.6-5.6-7.9 1-4.7 5.7-5.9 8-.5 4.3-8.7-3-11.4-7.6-8.8 7.1-7.2 7.9-13.5 2.1-21.1-8 6.1-8.1 12.3-4.5 20.8-4.7-5.4-12.1-2.5-9.5 6.2 3.4-5.2 7.9-2 7.2 3.1-.6 4.3-6.4 7.8-13.5 7.2-10.3-.9-10.9-8-11.2-13.8 2.5-.5 7.1 1.8 11 7.3L80.2 60c-4.1 4.4-8 5.3-12.3 5.4 1.4-4.4 8-11.6 8-11.6H55.5s6.4 7.2 7.9 11.6c-4.2-.1-8-1-12.3-5.4l1.4 16.4c3.9-5.5 8.5-7.7 10.9-7.3-.3 5.8-.9 12.8-11.1 13.8-7.2.6-12.9-2.9-13.5-7.2-.7-5 3.8-8.3 7.1-3.1 2.7-8.7-4.6-11.6-9.4-6.2 3.7-8.5 3.6-14.7-4.6-20.8-5.8 7.6-5 13.9 2.2 21.1-4.7-2.6-11.9.1-7.7 8.8 2.3-5.5 7.1-4.2 8.1.5.7 3.3-1.3 7.1-5.7 7.9-3.5.7-9-1.8-13.5-11.2 2.5.1 4.7 1.3 7.5 3.3l-4.7-15.4c-1.2 4.4-2.7 7.2-4.3 8.7-1.1-3-.9-5.3 0-10.2l-9.5 3.4c5 6.9 9.9 16.7 14 33.5 14.8-2.1 30.8-3.2 47.7-3.2z"
+            ></path>
+
+            <image src="/assets/images/govuk-logotype-crown.png" class="govuk-header__logotype-crown-fallback-image"></image>
+          </svg>
+          <span class="govuk-header__logotype-text">
+            GOV.UK
+          </span>
+        </span>
+
+      </a>
+    </div>
+
+    <div class="govuk-header__content">
+
+    <a href="/components/header" class="govuk-header__link govuk-header__link--service-name">
+      Service Name
+    </a>
+
+    </div>
+
+  </div>
+</header>
+"""
+        )
+    )
+
+
+def test_header_with_service_name_and_navigation(env):
+    template = env.from_string(
+"""
+{% from "header/macro.njk" import govukHeader %}
+
+{{ govukHeader({
+  "serviceName": "Service Name",
+  "serviceUrl": "/components/header",
+  "navigation": [
+    {
+      "href": "#1",
+      "text": "Navigation item 1",
+      "active": true
+    },
+    {
+      "href": "#2",
+      "text": "Navigation item 2"
+    },
+    {
+      "href": "#3",
+      "text": "Navigation item 3"
+    },
+    {
+      "href": "#4",
+      "text": "Navigation item 4"
+    }
+  ]
+}) }}
+"""
+    )
+    assert (
+        pytest.helpers.normalise_whitespace(template.render())
+        ==
+        pytest.helpers.normalise_whitespace(
+"""
+<header class="govuk-header " role="banner" data-module="header">
+  <div class="govuk-header__container govuk-width-container">
+
+    <div class="govuk-header__logo">
+      <a href="/" class="govuk-header__link govuk-header__link--homepage">
+        <span class="govuk-header__logotype">
+
+          <svg
+            role="presentation"
+            focusable="false"
+            class="govuk-header__logotype-crown"
+            xmlns="http://www.w3.org/2000/svg"
+            viewbox="0 0 132 97"
+            height="32"
+            width="36"
+          >
+            <path
+              fill="currentColor" fill-rule="evenodd"
+              d="M25 30.2c3.5 1.5 7.7-.2 9.1-3.7 1.5-3.6-.2-7.8-3.9-9.2-3.6-1.4-7.6.3-9.1 3.9-1.4 3.5.3 7.5 3.9 9zM9 39.5c3.6 1.5 7.8-.2 9.2-3.7 1.5-3.6-.2-7.8-3.9-9.1-3.6-1.5-7.6.2-9.1 3.8-1.4 3.5.3 7.5 3.8 9zM4.4 57.2c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.5-1.5-7.6.3-9.1 3.8-1.4 3.5.3 7.6 3.9 9.1zm38.3-21.4c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.6-1.5-7.6.3-9.1 3.8-1.3 3.6.4 7.7 3.9 9.1zm64.4-5.6c-3.6 1.5-7.8-.2-9.1-3.7-1.5-3.6.2-7.8 3.8-9.2 3.6-1.4 7.7.3 9.2 3.9 1.3 3.5-.4 7.5-3.9 9zm15.9 9.3c-3.6 1.5-7.7-.2-9.1-3.7-1.5-3.6.2-7.8 3.7-9.1 3.6-1.5 7.7.2 9.2 3.8 1.5 3.5-.3 7.5-3.8 9zm4.7 17.7c-3.6 1.5-7.8-.2-9.2-3.8-1.5-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.3 3.5-.4 7.6-3.9 9.1zM89.3 35.8c-3.6 1.5-7.8-.2-9.2-3.8-1.4-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.4 3.6-.3 7.7-3.9 9.1zM69.7 17.7l8.9 4.7V9.3l-8.9 2.8c-.2-.3-.5-.6-.9-.9L72.4 0H59.6l3.5 11.2c-.3.3-.6.5-.9.9l-8.8-2.8v13.1l8.8-4.7c.3.3.6.7.9.9l-5 15.4v.1c-.2.8-.4 1.6-.4 2.4 0 4.1 3.1 7.5 7 8.1h.2c.3 0 .7.1 1 .1.4 0 .7 0 1-.1h.2c4-.6 7.1-4.1 7.1-8.1 0-.8-.1-1.7-.4-2.4V34l-5.1-15.4c.4-.2.7-.6 1-.9zM66 92.8c16.9 0 32.8 1.1 47.1 3.2 4-16.9 8.9-26.7 14-33.5l-9.6-3.4c1 4.9 1.1 7.2 0 10.2-1.5-1.4-3-4.3-4.2-8.7L108.6 76c2.8-2 5-3.2 7.5-3.3-4.4 9.4-10 11.9-13.6 11.2-4.3-.8-6.3-4.6-5.6-7.9 1-4.7 5.7-5.9 8-.5 4.3-8.7-3-11.4-7.6-8.8 7.1-7.2 7.9-13.5 2.1-21.1-8 6.1-8.1 12.3-4.5 20.8-4.7-5.4-12.1-2.5-9.5 6.2 3.4-5.2 7.9-2 7.2 3.1-.6 4.3-6.4 7.8-13.5 7.2-10.3-.9-10.9-8-11.2-13.8 2.5-.5 7.1 1.8 11 7.3L80.2 60c-4.1 4.4-8 5.3-12.3 5.4 1.4-4.4 8-11.6 8-11.6H55.5s6.4 7.2 7.9 11.6c-4.2-.1-8-1-12.3-5.4l1.4 16.4c3.9-5.5 8.5-7.7 10.9-7.3-.3 5.8-.9 12.8-11.1 13.8-7.2.6-12.9-2.9-13.5-7.2-.7-5 3.8-8.3 7.1-3.1 2.7-8.7-4.6-11.6-9.4-6.2 3.7-8.5 3.6-14.7-4.6-20.8-5.8 7.6-5 13.9 2.2 21.1-4.7-2.6-11.9.1-7.7 8.8 2.3-5.5 7.1-4.2 8.1.5.7 3.3-1.3 7.1-5.7 7.9-3.5.7-9-1.8-13.5-11.2 2.5.1 4.7 1.3 7.5 3.3l-4.7-15.4c-1.2 4.4-2.7 7.2-4.3 8.7-1.1-3-.9-5.3 0-10.2l-9.5 3.4c5 6.9 9.9 16.7 14 33.5 14.8-2.1 30.8-3.2 47.7-3.2z"
+            ></path>
+
+            <image src="/assets/images/govuk-logotype-crown.png" class="govuk-header__logotype-crown-fallback-image"></image>
+          </svg>
+          <span class="govuk-header__logotype-text">
+            GOV.UK
+          </span>
+        </span>
+
+      </a>
+    </div>
+
+    <div class="govuk-header__content">
+
+    <a href="/components/header" class="govuk-header__link govuk-header__link--service-name">
+      Service Name
+    </a>
+
+    <button type="button" role="button" class="govuk-header__menu-button js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
+    <nav>
+      <ul id="navigation" class="govuk-header__navigation " aria-label="Top Level Navigation">
+
+            <li class="govuk-header__navigation-item govuk-header__navigation-item--active">
+              <a class="govuk-header__link" href="#1">
+                Navigation item 1
+              </a>
+            </li>
+
+            <li class="govuk-header__navigation-item">
+              <a class="govuk-header__link" href="#2">
+                Navigation item 2
+              </a>
+            </li>
+
+            <li class="govuk-header__navigation-item">
+              <a class="govuk-header__link" href="#3">
+                Navigation item 3
+              </a>
+            </li>
+
+            <li class="govuk-header__navigation-item">
+              <a class="govuk-header__link" href="#4">
+                Navigation item 4
+              </a>
+            </li>
+
+      </ul>
+    </nav>
+
+    </div>
+
+  </div>
+</header>
+"""
+        )
+    )

--- a/tests/components/test_header.py
+++ b/tests/components/test_header.py
@@ -225,3 +225,118 @@ def test_header_with_service_name_and_navigation(env):
 """
         )
     )
+
+
+@pytest.mark.xfail(reason="inline if-expression not targeted by regex")
+def test_header_with_service_name_and_navigation_and_autoescape(env):
+    from govuk_frontend.templates import Environment
+    env = Environment(autoescape=True)
+    template = env.from_string(
+"""
+{% from "header/macro.njk" import govukHeader %}
+
+{{ govukHeader({
+  "serviceName": "Service Name",
+  "serviceUrl": "/components/header",
+  "navigation": [
+    {
+      "href": "#1",
+      "text": "Navigation item 1",
+      "active": true
+    },
+    {
+      "href": "#2",
+      "text": "Navigation item 2"
+    },
+    {
+      "href": "#3",
+      "text": "Navigation item 3"
+    },
+    {
+      "href": "#4",
+      "text": "Navigation item 4"
+    }
+  ]
+}) }}
+"""
+    )
+    assert (
+        pytest.helpers.normalise_whitespace(template.render())
+        ==
+        pytest.helpers.normalise_whitespace(
+"""
+<header class="govuk-header " role="banner" data-module="header">
+  <div class="govuk-header__container govuk-width-container">
+
+    <div class="govuk-header__logo">
+      <a href="/" class="govuk-header__link govuk-header__link--homepage">
+        <span class="govuk-header__logotype">
+
+          <svg
+            role="presentation"
+            focusable="false"
+            class="govuk-header__logotype-crown"
+            xmlns="http://www.w3.org/2000/svg"
+            viewbox="0 0 132 97"
+            height="32"
+            width="36"
+          >
+            <path
+              fill="currentColor" fill-rule="evenodd"
+              d="M25 30.2c3.5 1.5 7.7-.2 9.1-3.7 1.5-3.6-.2-7.8-3.9-9.2-3.6-1.4-7.6.3-9.1 3.9-1.4 3.5.3 7.5 3.9 9zM9 39.5c3.6 1.5 7.8-.2 9.2-3.7 1.5-3.6-.2-7.8-3.9-9.1-3.6-1.5-7.6.2-9.1 3.8-1.4 3.5.3 7.5 3.8 9zM4.4 57.2c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.5-1.5-7.6.3-9.1 3.8-1.4 3.5.3 7.6 3.9 9.1zm38.3-21.4c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.6-1.5-7.6.3-9.1 3.8-1.3 3.6.4 7.7 3.9 9.1zm64.4-5.6c-3.6 1.5-7.8-.2-9.1-3.7-1.5-3.6.2-7.8 3.8-9.2 3.6-1.4 7.7.3 9.2 3.9 1.3 3.5-.4 7.5-3.9 9zm15.9 9.3c-3.6 1.5-7.7-.2-9.1-3.7-1.5-3.6.2-7.8 3.7-9.1 3.6-1.5 7.7.2 9.2 3.8 1.5 3.5-.3 7.5-3.8 9zm4.7 17.7c-3.6 1.5-7.8-.2-9.2-3.8-1.5-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.3 3.5-.4 7.6-3.9 9.1zM89.3 35.8c-3.6 1.5-7.8-.2-9.2-3.8-1.4-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.4 3.6-.3 7.7-3.9 9.1zM69.7 17.7l8.9 4.7V9.3l-8.9 2.8c-.2-.3-.5-.6-.9-.9L72.4 0H59.6l3.5 11.2c-.3.3-.6.5-.9.9l-8.8-2.8v13.1l8.8-4.7c.3.3.6.7.9.9l-5 15.4v.1c-.2.8-.4 1.6-.4 2.4 0 4.1 3.1 7.5 7 8.1h.2c.3 0 .7.1 1 .1.4 0 .7 0 1-.1h.2c4-.6 7.1-4.1 7.1-8.1 0-.8-.1-1.7-.4-2.4V34l-5.1-15.4c.4-.2.7-.6 1-.9zM66 92.8c16.9 0 32.8 1.1 47.1 3.2 4-16.9 8.9-26.7 14-33.5l-9.6-3.4c1 4.9 1.1 7.2 0 10.2-1.5-1.4-3-4.3-4.2-8.7L108.6 76c2.8-2 5-3.2 7.5-3.3-4.4 9.4-10 11.9-13.6 11.2-4.3-.8-6.3-4.6-5.6-7.9 1-4.7 5.7-5.9 8-.5 4.3-8.7-3-11.4-7.6-8.8 7.1-7.2 7.9-13.5 2.1-21.1-8 6.1-8.1 12.3-4.5 20.8-4.7-5.4-12.1-2.5-9.5 6.2 3.4-5.2 7.9-2 7.2 3.1-.6 4.3-6.4 7.8-13.5 7.2-10.3-.9-10.9-8-11.2-13.8 2.5-.5 7.1 1.8 11 7.3L80.2 60c-4.1 4.4-8 5.3-12.3 5.4 1.4-4.4 8-11.6 8-11.6H55.5s6.4 7.2 7.9 11.6c-4.2-.1-8-1-12.3-5.4l1.4 16.4c3.9-5.5 8.5-7.7 10.9-7.3-.3 5.8-.9 12.8-11.1 13.8-7.2.6-12.9-2.9-13.5-7.2-.7-5 3.8-8.3 7.1-3.1 2.7-8.7-4.6-11.6-9.4-6.2 3.7-8.5 3.6-14.7-4.6-20.8-5.8 7.6-5 13.9 2.2 21.1-4.7-2.6-11.9.1-7.7 8.8 2.3-5.5 7.1-4.2 8.1.5.7 3.3-1.3 7.1-5.7 7.9-3.5.7-9-1.8-13.5-11.2 2.5.1 4.7 1.3 7.5 3.3l-4.7-15.4c-1.2 4.4-2.7 7.2-4.3 8.7-1.1-3-.9-5.3 0-10.2l-9.5 3.4c5 6.9 9.9 16.7 14 33.5 14.8-2.1 30.8-3.2 47.7-3.2z"
+            ></path>
+
+            <image src="/assets/images/govuk-logotype-crown.png" class="govuk-header__logotype-crown-fallback-image"></image>
+          </svg>
+          <span class="govuk-header__logotype-text">
+            GOV.UK
+          </span>
+        </span>
+
+      </a>
+    </div>
+
+    <div class="govuk-header__content">
+
+    <a href="/components/header" class="govuk-header__link govuk-header__link--service-name">
+      Service Name
+    </a>
+
+    <button type="button" role="button" class="govuk-header__menu-button js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
+    <nav>
+      <ul id="navigation" class="govuk-header__navigation " aria-label="Top Level Navigation">
+
+            <li class="govuk-header__navigation-item govuk-header__navigation-item--active">
+              <a class="govuk-header__link" href="#1">
+                Navigation item 1
+              </a>
+            </li>
+
+            <li class="govuk-header__navigation-item">
+              <a class="govuk-header__link" href="#2">
+                Navigation item 2
+              </a>
+            </li>
+
+            <li class="govuk-header__navigation-item">
+              <a class="govuk-header__link" href="#3">
+                Navigation item 3
+              </a>
+            </li>
+
+            <li class="govuk-header__navigation-item">
+              <a class="govuk-header__link" href="#4">
+                Navigation item 4
+              </a>
+            </li>
+
+      </ul>
+    </nav>
+
+    </div>
+
+  </div>
+</header>
+"""
+        )
+    )

--- a/tests/components/test_hint.py
+++ b/tests/components/test_hint.py
@@ -1,0 +1,40 @@
+
+from govuk_frontend.templates import Environment
+
+
+def test_hint_template():
+    env = Environment()
+    template = env.get_template("components/hint/template.njk")
+    assert (
+        template.render(params={
+            "text": "It’s on your National Insurance card, benefit letter, payslip or P60.\nFor example, ‘QQ 12 34 56 C‘.\n",
+        })
+        ==
+"""<span class="govuk-hint">
+  It’s on your National Insurance card, benefit letter, payslip or P60.
+For example, ‘QQ 12 34 56 C‘.
+
+</span>"""
+    )
+
+
+def test_hint():
+    env = Environment()
+    template = env.from_string(
+"""{% from "components/hint/macro.njk" import govukHint %}
+
+{{ govukHint({
+  "text": "It’s on your National Insurance card, benefit letter, payslip or P60.\nFor example, ‘QQ 12 34 56 C‘.\n"
+}) }}"""
+    )
+    assert (
+        template.render()
+        ==
+"""
+
+<span class="govuk-hint">
+  It’s on your National Insurance card, benefit letter, payslip or P60.
+For example, ‘QQ 12 34 56 C‘.
+
+</span>"""
+    )

--- a/tests/components/test_input.py
+++ b/tests/components/test_input.py
@@ -1,4 +1,6 @@
 
+import pytest
+
 from govuk_frontend.templates import Environment
 
 
@@ -29,4 +31,89 @@ def test_input():
 
   <input class="govuk-input" id="input-example" name="test-name" type="text">
 </div>"""
+    )
+
+
+def test_input_with_hint_text():
+    env = Environment()
+    template = env.from_string(
+r"""
+{% from "input/macro.njk" import govukInput %}
+
+{{ govukInput({
+  "label": {
+    "text": "National insurance number"
+  },
+  "hint": {
+    "text": "It’s on your National Insurance card, benefit letter, payslip or P60\. For example, ‘QQ 12 34 56 C’."
+  },
+  "id": "input-with-hint-text",
+  "name": "test-name-2"
+}) }}
+"""
+    )
+    assert (
+        pytest.helpers.normalise_whitespace(template.render())
+        ==
+        pytest.helpers.normalise_whitespace(
+r"""
+<div class="govuk-form-group">
+  <label class="govuk-label" for="input-with-hint-text">
+    National insurance number
+  </label>
+
+  <span id="input-with-hint-text-hint" class="govuk-hint">
+    It’s on your National Insurance card, benefit letter, payslip or P60\. For example, ‘QQ 12 34 56 C’.
+  </span>
+
+  <input class="govuk-input" id="input-with-hint-text" name="test-name-2" type="text" aria-describedby="input-with-hint-text-hint">
+</div>
+"""
+        )
+    )
+
+
+def test_input_with_error_mesage():
+    env = Environment()
+    template = env.from_string(
+r"""
+{% from "input/macro.njk" import govukInput %}
+
+{{ govukInput({
+  "label": {
+    "text": "National Insurance number"
+  },
+  "hint": {
+    "text": "It’s on your National Insurance card, benefit letter, payslip or P60\. For example, ‘QQ 12 34 56 C’."
+  },
+  "id": "input-with-error-message",
+  "name": "test-name-3",
+  "errorMessage": {
+    "text": "Error message goes here"
+  }
+}) }}
+"""
+    )
+    assert (
+        pytest.helpers.normalise_whitespace(template.render())
+        ==
+        pytest.helpers.normalise_whitespace(
+            r"""
+            <div class="govuk-form-group govuk-form-group--error">
+              <label class="govuk-label" for="input-with-error-message">
+                National Insurance number
+              </label>
+
+              <span id="input-with-error-message-hint" class="govuk-hint">
+                It’s on your National Insurance card, benefit letter, payslip or P60\. For example, ‘QQ 12 34 56 C’.
+              </span>
+
+              <span id="input-with-error-message-error" class="govuk-error-message">
+                Error message goes here
+              </span>
+
+              <input class="govuk-input govuk-input--error" id="input-with-error-message" name="test-name-3" type="text" aria-describedby="input-with-error-message-hint input-with-error-message-error">
+            </div>
+            """
+        )
     )

--- a/tests/components/test_input.py
+++ b/tests/components/test_input.py
@@ -1,0 +1,32 @@
+
+from govuk_frontend.templates import Environment
+
+
+def test_input():
+    env = Environment()
+    template = env.from_string(
+"""
+{% from "input/macro.njk" import govukInput %}
+
+{{ govukInput({
+  "label": {
+    "text": "National Insurance number"
+  },
+  "id": "input-example",
+  "name": "test-name"
+}) }}
+"""
+    )
+    assert (
+        template.render()
+        ==
+"""\n\n\n\n
+<div class="govuk-form-group">
+  <label class="govuk-label" for="input-example">
+    National Insurance number
+  </label>
+
+
+  <input class="govuk-input" id="input-example" name="test-name" type="text">
+</div>"""
+    )

--- a/tests/components/test_input.py
+++ b/tests/components/test_input.py
@@ -117,3 +117,38 @@ r"""
             """
         )
     )
+
+
+def test_input_with_attributes():
+    env = Environment()
+    template = env.from_string(
+"""
+{% from "input/macro.njk" import govukInput %}
+
+{{ govukInput({
+  "label": {
+    "text": "Number"
+  },
+  "id": "input-example",
+  "name": "test-name",
+  "attributes": {
+    "pattern": "[0-9]*",
+  },
+}) }}
+"""
+    )
+    assert (
+        pytest.helpers.normalise_whitespace(template.render())
+        ==
+        pytest.helpers.normalise_whitespace(
+"""
+<div class="govuk-form-group">
+  <label class="govuk-label" for="input-example">
+    Number
+  </label>
+
+  <input class="govuk-input" id="input-example" name="test-name" type="text" pattern="[0-9]*">
+</div>
+"""
+        )
+    )

--- a/tests/components/test_inset_text.py
+++ b/tests/components/test_inset_text.py
@@ -1,0 +1,48 @@
+
+import pytest
+
+
+def test_inset_text(env):
+    template = env.from_string(
+"""
+{% from "inset-text/macro.njk" import govukInsetText %}
+
+{{ govukInsetText({
+  "text": "It can take up to 8 weeks to register a lasting power of attorney if there are no mistakes in the application."
+}) }}
+"""
+    )
+    assert (
+        pytest.helpers.normalise_whitespace(template.render())
+        ==
+        pytest.helpers.normalise_whitespace(
+"""
+<div class="govuk-inset-text">
+  It can take up to 8 weeks to register a lasting power of attorney if there are no mistakes in the application.
+</div>
+"""
+        )
+    )
+
+
+def test_inset_text_with_html(env):
+    template = env.from_string(
+r"""
+{% from "inset-text/macro.njk" import govukInsetText %}
+
+{{ govukInsetText({
+  "html": "It can take up to 8 weeks to register a <a class=\"govuk-link\" href=\"#\">lasting power of attorney</a> if there are no mistakes in the application."
+}) }}
+"""
+    )
+    assert (
+        pytest.helpers.normalise_whitespace(template.render())
+        ==
+        pytest.helpers.normalise_whitespace(
+"""
+<div class="govuk-inset-text">
+  It can take up to 8 weeks to register a <a class="govuk-link" href="#">lasting power of attorney</a> if there are no mistakes in the application.
+</div>
+"""
+        )
+    )

--- a/tests/components/test_label.py
+++ b/tests/components/test_label.py
@@ -1,4 +1,6 @@
 
+import pytest
+
 from textwrap import dedent
 
 from govuk_frontend.templates import Environment
@@ -44,4 +46,53 @@ def test_default_example_macro():
         <label class="govuk-label">
           National Insurance number
         </label>\n\n\n""")
+    )
+
+
+def test_label_for():
+    env = Environment()
+    template = env.from_string(
+"""
+{% from "label/macro.njk" import govukLabel %}
+
+{{ govukLabel({
+  "text": "National Insurance number",
+  "for": "label-example",
+}) }}
+"""
+    )
+    assert (
+        template.render()
+        ==
+"""\n\n\n\n\n\n\n
+<label class="govuk-label" for="label-example">
+  National Insurance number
+</label>\n\n
+"""
+    )
+
+
+def test_label_with_undefined_params():
+    env = Environment()
+    template = env.from_string(
+"""
+{% from "label/macro.njk" import govukLabel %}
+
+{{ govukLabel({
+  "html": html,
+  "text": "National Insurance number",
+  "classes": classes,
+  "isPageHeading": isPageHeading,
+  "for": "label-example",
+}) }}
+"""
+    )
+    assert (
+        template.render()
+        ==
+"""\n\n\n\n\n\n\n
+<label class="govuk-label" for="label-example">
+  National Insurance number
+</label>\n\n
+"""
     )

--- a/tests/components/test_panel.py
+++ b/tests/components/test_panel.py
@@ -1,0 +1,65 @@
+
+import pytest
+
+
+def test_panel(env):
+    template = env.from_string(
+"""
+{% from "panel/macro.njk" import govukPanel %}
+
+{{ govukPanel({
+  "titleHtml": "Application complete",
+  "text": "Your reference number: HDJ2123F"
+}) }}
+"""
+    )
+    assert (
+        pytest.helpers.normalise_whitespace(template.render())
+        ==
+        pytest.helpers.normalise_whitespace(
+"""
+<div class="govuk-panel govuk-panel--confirmation">
+  <h1 class="govuk-panel__title">
+    Application complete
+  </h1>
+
+  <div class="govuk-panel__body">
+    Your reference number: HDJ2123F
+  </div>
+
+</div>
+"""
+        )
+    )
+
+
+def test_panel_custom_heading_level(env):
+    template = env.from_string(
+"""
+{% from "panel/macro.njk" import govukPanel %}
+
+{{ govukPanel({
+  "titleText": "Application complete",
+  "headingLevel": 2,
+  "text": "Your reference number: HDJ2123F"
+}) }}
+"""
+    )
+    assert (
+        pytest.helpers.normalise_whitespace(template.render())
+        ==
+        pytest.helpers.normalise_whitespace(
+"""
+<div class="govuk-panel govuk-panel--confirmation">
+  <h2 class="govuk-panel__title">
+    Application complete
+  </h2>
+
+  <div class="govuk-panel__body">
+    Your reference number: HDJ2123F
+  </div>
+
+</div>
+"""
+        )
+    )

--- a/tests/components/test_phase_banner.py
+++ b/tests/components/test_phase_banner.py
@@ -1,0 +1,66 @@
+
+import pytest
+
+
+@pytest.mark.xfail(reason="tests with html causing lexer errors")
+def test_phase_banner(env):
+    template = env.from_string(
+"""
+{% from "phase-banner/macro.njk" import govukPhaseBanner %}
+
+{{ govukPhaseBanner({
+  "tag": {
+    "text": "alpha"
+  },
+  "html": "This is a new service - your <a href=\"#\" class=\"govuk-link\">feedback</a> will help us to improve it."
+}) }}
+"""
+    )
+    assert (
+        pytest.helpers.normalise_whitespace(template.render())
+        ==
+        pytest.helpers.normalise_whitespace(
+"""
+<div class="govuk-phase-banner">
+  <p class="govuk-phase-banner__content"><strong class="govuk-tag govuk-phase-banner__content__tag ">
+  alpha
+</strong>
+<span class="govuk-phase-banner__text">
+      This is a new service - your <a href="#" class="govuk-link">feedback</a> will help us to improve it.
+    </span>
+  </p>
+</div>
+"""
+        )
+    )
+
+
+def test_phase_banner_with_text(env):
+    template = env.from_string(
+"""
+{% from "phase-banner/macro.njk" import govukPhaseBanner %}
+
+{{ govukPhaseBanner({
+  "tag": {
+    "text": "alpha"
+  },
+  "text": "This is a new service - your feedback will help us to improve it."
+}) }}
+"""
+    )
+    assert (
+        pytest.helpers.normalise_whitespace(template.render())
+        ==
+        pytest.helpers.normalise_whitespace(
+"""
+<div class="govuk-phase-banner">
+  <p class="govuk-phase-banner__content"><strong class="govuk-tag govuk-phase-banner__content__tag ">
+  alpha
+</strong><span class="govuk-phase-banner__text">
+      This is a new service - your feedback will help us to improve it.
+    </span>
+  </p>
+</div>
+"""
+        )
+    )

--- a/tests/components/test_phase_banner.py
+++ b/tests/components/test_phase_banner.py
@@ -2,10 +2,10 @@
 import pytest
 
 
-@pytest.mark.xfail(reason="tests with html causing lexer errors")
+@pytest.mark.xfail(reason="slight difference in line splits")
 def test_phase_banner(env):
     template = env.from_string(
-"""
+r"""
 {% from "phase-banner/macro.njk" import govukPhaseBanner %}
 
 {{ govukPhaseBanner({

--- a/tests/components/test_radios.py
+++ b/tests/components/test_radios.py
@@ -4,7 +4,6 @@ import pytest
 from govuk_frontend.templates import Environment
 
 
-@pytest.mark.xfail(reason="issue#4: template tries to set variable in outer scope")
 def test_radios():
     env = Environment()
     template = env.from_string(
@@ -140,7 +139,6 @@ def test_radios_without_fieldset():
     )
 
 
-@pytest.mark.xfail(reason="issue#4: template tries to set variable in outer scope")
 def test_radios_with_disabled(env):
     template = env.from_string(
 """
@@ -214,7 +212,6 @@ def test_radios_with_disabled(env):
     )
 
 
-@pytest.mark.xfail(reason="issue#4: template tries to set variable in outer scope")
 def test_radios_with_legend_as_page_heading(env):
     template = env.from_string(
 r"""
@@ -290,7 +287,6 @@ r"""
     )
 
 
-@pytest.mark.xfail(reason="issue#4: template tries to set variable in outer scope")
 def test_radios_with_a_medium_legend(env):
     template = env.from_string(
 r"""
@@ -586,7 +582,6 @@ def test_radios_without_fieldset(env):
     )
 
 
-@pytest.mark.xfail(reason="issue#4: template tries to set variable in outer scope")
 def test_radios_with_all_fieldset_attributes(env):
     template = env.from_string(
 """

--- a/tests/components/test_radios.py
+++ b/tests/components/test_radios.py
@@ -138,3 +138,534 @@ def test_radios_without_fieldset():
 """
         ).strip()
     )
+
+
+@pytest.mark.xfail(reason="issue#4: template tries to set variable in outer scope")
+def test_radios_with_disabled(env):
+    template = env.from_string(
+"""
+{% from "radios/macro.njk" import govukRadios %}
+
+{{ govukRadios({
+  "idPrefix": "example-disabled",
+  "name": "example-disabled",
+  "fieldset": {
+    "legend": {
+      "text": "Have you changed your name?"
+    }
+  },
+  "hint": {
+    "text": "This includes changing your last name or spelling your name differently."
+  },
+  "items": [
+    {
+      "value": "yes",
+      "text": "Yes",
+      "disabled": true
+    },
+    {
+      "value": "no",
+      "text": "No",
+      "disabled": true
+    }
+  ]
+}) }}
+"""
+    )
+    assert (
+        pytest.helpers.normalise_whitespace(template.render())
+        ==
+        pytest.helpers.normalise_whitespace(
+"""
+<div class="govuk-form-group">
+
+  <fieldset class="govuk-fieldset" aria-describedby="example-disabled-hint">
+
+  <legend class="govuk-fieldset__legend">
+    Have you changed your name?
+  </legend>
+
+  <span id="example-disabled-hint" class="govuk-hint">
+    This includes changing your last name or spelling your name differently.
+  </span>
+
+  <div class="govuk-radios">
+
+    <div class="govuk-radios__item">
+      <input class="govuk-radios__input" id="example-disabled-1" name="example-disabled" type="radio" value="yes" disabled>
+      <label class="govuk-label govuk-radios__label" for="example-disabled-1">
+        Yes
+      </label>
+    </div>
+
+    <div class="govuk-radios__item">
+      <input class="govuk-radios__input" id="example-disabled-2" name="example-disabled" type="radio" value="no" disabled>
+      <label class="govuk-label govuk-radios__label" for="example-disabled-2">
+        No
+      </label>
+    </div>
+
+  </div>
+  </fieldset>
+
+</div>
+"""
+        )
+    )
+
+
+@pytest.mark.xfail(reason="issue#4: template tries to set variable in outer scope")
+def test_radios_with_legend_as_page_heading(env):
+    template = env.from_string(
+r"""
+{% from "radios/macro.njk" import govukRadios %}
+
+{{ govukRadios({
+  "idPrefix": "housing-act",
+  "name": "housing-act",
+  "fieldset": {
+    "legend": {
+      "text": "Which part of the Housing Act was your licence issued under?",
+      "classes": "govuk-fieldset__legend--l",
+      "isPageHeading": true
+    }
+  },
+  "hint": {
+    "text": "Select one of the options below."
+  },
+  "items": [
+    {
+      "value": "part-2",
+      "html": "<span class=\"govuk-heading-s govuk-!-margin-bottom-1\">Part 2 of the Housing Act 2004</span> For properties that are 3 or more stories high and occupied by 5 or more people"
+    },
+    {
+      "value": "part-3",
+      "html": "<span class=\"govuk-heading-s govuk-!-margin-bottom-1\">Part 3 of the Housing Act 2004</span> For properties that are within a geographical area defined by a local council"
+    }
+  ]
+}) }}
+"""
+    )
+    assert (
+        pytest.helpers.normalise_whitespace(template.render())
+        ==
+        pytest.helpers.normalise_whitespace(
+"""
+<div class="govuk-form-group">
+
+  <fieldset class="govuk-fieldset" aria-describedby="housing-act-hint">
+
+  <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+    <h1 class="govuk-fieldset__heading">
+      Which part of the Housing Act was your licence issued under?
+    </h1>
+  </legend>
+
+  <span id="housing-act-hint" class="govuk-hint">
+    Select one of the options below.
+  </span>
+
+  <div class="govuk-radios">
+
+    <div class="govuk-radios__item">
+      <input class="govuk-radios__input" id="housing-act-1" name="housing-act" type="radio" value="part-2">
+      <label class="govuk-label govuk-radios__label" for="housing-act-1">
+        <span class="govuk-heading-s govuk-!-margin-bottom-1">Part 2 of the Housing Act 2004</span> For properties that are 3 or more stories high and occupied by 5 or more people
+      </label>
+    </div>
+
+    <div class="govuk-radios__item">
+      <input class="govuk-radios__input" id="housing-act-2" name="housing-act" type="radio" value="part-3">
+      <label class="govuk-label govuk-radios__label" for="housing-act-2">
+        <span class="govuk-heading-s govuk-!-margin-bottom-1">Part 3 of the Housing Act 2004</span> For properties that are within a geographical area defined by a local council
+      </label>
+    </div>
+
+  </div>
+  </fieldset>
+
+</div>
+"""
+        )
+    )
+
+
+@pytest.mark.xfail(reason="issue#4: template tries to set variable in outer scope")
+def test_radios_with_a_medium_legend(env):
+    template = env.from_string(
+r"""
+{% from "radios/macro.njk" import govukRadios %}
+
+{{ govukRadios({
+  "idPrefix": "housing-act",
+  "name": "housing-act",
+  "fieldset": {
+    "legend": {
+      "text": "Which part of the Housing Act was your licence issued under?",
+      "classes": "govuk-fieldset__legend--m"
+    }
+  },
+  "hint": {
+    "text": "Select one of the options below."
+  },
+  "items": [
+    {
+      "value": "part-2",
+      "html": "<span class=\"govuk-heading-s govuk-!-margin-bottom-1\">Part 2 of the Housing Act 2004</span> For properties that are 3 or more stories high and occupied by 5 or more people"
+    },
+    {
+      "value": "part-3",
+      "html": "<span class=\"govuk-heading-s govuk-!-margin-bottom-1\">Part 3 of the Housing Act 2004</span> For properties that are within a geographical area defined by a local council"
+    }
+  ]
+}) }}
+"""
+    )
+    assert (
+        pytest.helpers.normalise_whitespace(template.render())
+        ==
+        pytest.helpers.normalise_whitespace(
+"""
+<div class="govuk-form-group">
+
+  <fieldset class="govuk-fieldset" aria-describedby="housing-act-hint">
+
+  <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+    Which part of the Housing Act was your licence issued under?
+  </legend>
+
+  <span id="housing-act-hint" class="govuk-hint">
+    Select one of the options below.
+  </span>
+
+  <div class="govuk-radios">
+
+    <div class="govuk-radios__item">
+      <input class="govuk-radios__input" id="housing-act-1" name="housing-act" type="radio" value="part-2">
+      <label class="govuk-label govuk-radios__label" for="housing-act-1">
+        <span class="govuk-heading-s govuk-!-margin-bottom-1">Part 2 of the Housing Act 2004</span> For properties that are 3 or more stories high and occupied by 5 or more people
+      </label>
+    </div>
+
+    <div class="govuk-radios__item">
+      <input class="govuk-radios__input" id="housing-act-2" name="housing-act" type="radio" value="part-3">
+      <label class="govuk-label govuk-radios__label" for="housing-act-2">
+        <span class="govuk-heading-s govuk-!-margin-bottom-1">Part 3 of the Housing Act 2004</span> For properties that are within a geographical area defined by a local council
+      </label>
+    </div>
+
+  </div>
+  </fieldset>
+
+</div>
+"""
+        )
+    )
+
+
+def test_radios_with_a_divider(env):
+    template = env.from_string(
+"""
+{% from "radios/macro.njk" import govukRadios %}
+
+{{ govukRadios({
+  "idPrefix": "example-divider",
+  "name": "example",
+  "fieldset": {
+    "legend": {
+      "text": "How do you want to sign in?"
+    }
+  },
+  "items": [
+    {
+      "value": "governement-gateway",
+      "text": "Use Government Gateway"
+    },
+    {
+      "value": "govuk-verify",
+      "text": "Use GOV.UK Verify"
+    },
+    {
+      "divider": "or"
+    },
+    {
+      "value": "create-account",
+      "text": "Create an account"
+    }
+  ]
+}) }}
+
+"""
+    )
+    assert (
+        pytest.helpers.normalise_whitespace(template.render())
+        ==
+        pytest.helpers.normalise_whitespace(
+"""
+<div class="govuk-form-group">
+
+  <fieldset class="govuk-fieldset">
+
+  <legend class="govuk-fieldset__legend">
+    How do you want to sign in?
+  </legend>
+
+  <div class="govuk-radios">
+
+    <div class="govuk-radios__item">
+      <input class="govuk-radios__input" id="example-divider-1" name="example" type="radio" value="governement-gateway">
+      <label class="govuk-label govuk-radios__label" for="example-divider-1">
+        Use Government Gateway
+      </label>
+    </div>
+
+    <div class="govuk-radios__item">
+      <input class="govuk-radios__input" id="example-divider-2" name="example" type="radio" value="govuk-verify">
+      <label class="govuk-label govuk-radios__label" for="example-divider-2">
+        Use GOV.UK Verify
+      </label>
+    </div>
+
+    <div class="govuk-radios__divider">or</div>
+
+    <div class="govuk-radios__item">
+      <input class="govuk-radios__input" id="example-divider-4" name="example" type="radio" value="create-account">
+      <label class="govuk-label govuk-radios__label" for="example-divider-4">
+        Create an account
+      </label>
+    </div>
+
+  </div>
+  </fieldset>
+
+</div>
+"""
+        )
+    )
+
+
+@pytest.mark.xfail(reason="apostrophe not escaped")
+def test_radios_with_hints_on_items(env):
+    template = env.from_string(
+"""
+{% from "radios/macro.njk" import govukRadios %}
+
+{{ govukRadios({
+  "idPrefix": "gov",
+  "name": "gov",
+  "fieldset": {
+    "legend": {
+      "text": "How do you want to sign in?",
+      "isPageHeading": true
+    }
+  },
+  "items": [
+    {
+      "value": "gateway",
+      "text": "Sign in with Government Gateway",
+      "hint": {
+        "text": "You'll have a user ID if you've registered for Self Assessment or filed a tax return online before."
+      }
+    },
+    {
+      "value": "verify",
+      "text": "Sign in with GOV.UK Verify",
+      "hint": {
+        "text": "You’ll have an account if you’ve already proved your identity with either Barclays, CitizenSafe, Digidentity, Experian, Post Office, Royal Mail or SecureIdentity."
+      }
+    }
+  ]
+}) }}
+"""
+    )
+    assert (
+        pytest.helpers.normalise_whitespace(template.render())
+        ==
+        pytest.helpers.normalise_whitespace(
+"""
+<div class="govuk-form-group">
+
+  <fieldset class="govuk-fieldset">
+
+  <legend class="govuk-fieldset__legend">
+    <h1 class="govuk-fieldset__heading">
+      How do you want to sign in?
+    </h1>
+  </legend>
+
+  <div class="govuk-radios">
+
+    <div class="govuk-radios__item">
+      <input class="govuk-radios__input" id="gov-1" name="gov" type="radio" value="gateway" aria-describedby="gov-1-item-hint">
+      <label class="govuk-label govuk-radios__label" for="gov-1">
+        Sign in with Government Gateway
+      </label>
+      <span id="gov-1-item-hint" class="govuk-hint govuk-radios__hint">
+        You&#39;ll have a user ID if you&#39;ve registered for Self Assessment or filed a tax return online before.
+      </span>
+    </div>
+
+    <div class="govuk-radios__item">
+      <input class="govuk-radios__input" id="gov-2" name="gov" type="radio" value="verify" aria-describedby="gov-2-item-hint">
+      <label class="govuk-label govuk-radios__label" for="gov-2">
+        Sign in with GOV.UK Verify
+      </label>
+      <span id="gov-2-item-hint" class="govuk-hint govuk-radios__hint">
+        You’ll have an account if you’ve already proved your identity with either Barclays, CitizenSafe, Digidentity, Experian, Post Office, Royal Mail or SecureIdentity.
+      </span>
+    </div>
+
+  </div>
+  </fieldset>
+
+</div>
+"""
+        )
+    )
+
+
+def test_radios_without_fieldset(env):
+    template = env.from_string(
+"""
+{% from "radios/macro.njk" import govukRadios %}
+
+{{ govukRadios({
+  "name": "colours",
+  "items": [
+    {
+      "value": "red",
+      "text": "Red"
+    },
+    {
+      "value": "green",
+      "text": "Green"
+    },
+    {
+      "value": "blue",
+      "text": "Blue"
+    }
+  ]
+}) }}
+"""
+    )
+    assert (
+        pytest.helpers.normalise_whitespace(template.render())
+        ==
+        pytest.helpers.normalise_whitespace(
+"""
+<div class="govuk-form-group">
+
+  <div class="govuk-radios">
+
+    <div class="govuk-radios__item">
+      <input class="govuk-radios__input" id="colours-1" name="colours" type="radio" value="red">
+      <label class="govuk-label govuk-radios__label" for="colours-1">
+        Red
+      </label>
+    </div>
+
+    <div class="govuk-radios__item">
+      <input class="govuk-radios__input" id="colours-2" name="colours" type="radio" value="green">
+      <label class="govuk-label govuk-radios__label" for="colours-2">
+        Green
+      </label>
+    </div>
+
+    <div class="govuk-radios__item">
+      <input class="govuk-radios__input" id="colours-3" name="colours" type="radio" value="blue">
+      <label class="govuk-label govuk-radios__label" for="colours-3">
+        Blue
+      </label>
+    </div>
+
+  </div>
+
+</div>
+"""
+        )
+    )
+
+
+@pytest.mark.xfail(reason="issue#4: template tries to set variable in outer scope")
+def test_radios_with_all_fieldset_attributes(env):
+    template = env.from_string(
+"""
+{% from "radios/macro.njk" import govukRadios %}
+
+{{ govukRadios({
+  "idPrefix": "example",
+  "name": "example",
+  "errorMessage": {
+    "text": "Please select an option"
+  },
+  "fieldset": {
+    "classes": "app-fieldset--custom-modifier",
+    "attributes": {
+      "data-attribute": "value",
+      "data-second-attribute": "second-value"
+    },
+    "legend": {
+      "text": "Have you changed your name?"
+    }
+  },
+  "hint": {
+    "text": "This includes changing your last name or spelling your name differently."
+  },
+  "items": [
+    {
+      "value": "yes",
+      "text": "Yes"
+    },
+    {
+      "value": "no",
+      "text": "No",
+      "checked": true
+    }
+  ]
+}) }}
+"""
+    )
+    assert (
+        pytest.helpers.normalise_whitespace(template.render())
+        ==
+        pytest.helpers.normalise_whitespace(
+"""
+<div class="govuk-form-group govuk-form-group--error">
+
+  <fieldset class="govuk-fieldset app-fieldset--custom-modifier" aria-describedby="example-hint example-error" data-attribute="value" data-second-attribute="second-value">
+
+  <legend class="govuk-fieldset__legend">
+    Have you changed your name?
+  </legend>
+
+  <span id="example-hint" class="govuk-hint">
+    This includes changing your last name or spelling your name differently.
+  </span>
+
+  <span id="example-error" class="govuk-error-message">
+    Please select an option
+  </span>
+
+  <div class="govuk-radios">
+
+    <div class="govuk-radios__item">
+      <input class="govuk-radios__input" id="example-1" name="example" type="radio" value="yes">
+      <label class="govuk-label govuk-radios__label" for="example-1">
+        Yes
+      </label>
+    </div>
+
+    <div class="govuk-radios__item">
+      <input class="govuk-radios__input" id="example-2" name="example" type="radio" value="no" checked>
+      <label class="govuk-label govuk-radios__label" for="example-2">
+        No
+      </label>
+    </div>
+
+  </div>
+  </fieldset>
+
+</div>
+"""
+        )
+    )

--- a/tests/components/test_radios.py
+++ b/tests/components/test_radios.py
@@ -1,0 +1,140 @@
+
+import pytest
+
+from govuk_frontend.templates import Environment
+
+
+@pytest.mark.xfail(reason="issue#4: template tries to set variable in outer scope")
+def test_radios():
+    env = Environment()
+    template = env.from_string(
+"""{% from "radios/macro.njk" import govukRadios %}
+
+{{ govukRadios({
+  "idPrefix": "example",
+  "name": "example",
+  "fieldset": {
+    "legend": {
+      "text": "Have you changed your name?"
+    }
+  },
+  "hint": {
+    "text": "This includes changing your last name or spelling your name differently."
+  },
+  "items": [
+    {
+      "value": "yes",
+      "text": "Yes"
+    },
+    {
+      "value": "no",
+      "text": "No",
+      "checked": true
+    }
+  ]
+}) }}
+"""
+    )
+    assert (
+        pytest.helpers.normalise_whitespace(template.render())
+        ==
+        pytest.helpers.normalise_whitespace(
+"""
+<div class="govuk-form-group">
+
+  <fieldset class="govuk-fieldset" aria-describedby="example-hint">
+
+  <legend class="govuk-fieldset__legend">
+    Have you changed your name?
+  </legend>
+
+  <span id="example-hint" class="govuk-hint">
+    This includes changing your last name or spelling your name differently.
+  </span>
+
+  <div class="govuk-radios">
+
+    <div class="govuk-radios__item">
+      <input class="govuk-radios__input" id="example-1" name="example" type="radio" value="yes">
+      <label class="govuk-label govuk-radios__label" for="example-1">
+        Yes
+      </label>
+    </div>
+
+    <div class="govuk-radios__item">
+      <input class="govuk-radios__input" id="example-2" name="example" type="radio" value="no" checked>
+      <label class="govuk-label govuk-radios__label" for="example-2">
+        No
+      </label>
+    </div>
+
+  </div>
+  </fieldset>
+
+</div>
+"""
+        )
+    )
+
+
+def test_radios_without_fieldset():
+    env = Environment()
+    template = env.from_string(
+"""
+{% from "radios/macro.njk" import govukRadios %}
+
+{{ govukRadios({
+  "name": "colours",
+  "items": [
+    {
+      "value": "red",
+      "text": "Red"
+    },
+    {
+      "value": "green",
+      "text": "Green"
+    },
+    {
+      "value": "blue",
+      "text": "Blue"
+    }
+  ]
+}) }}
+"""
+    )
+    assert (
+        pytest.helpers.normalise_whitespace(template.render())
+        ==
+        pytest.helpers.normalise_whitespace(
+"""
+<div class="govuk-form-group">
+
+  <div class="govuk-radios">
+
+    <div class="govuk-radios__item">
+      <input class="govuk-radios__input" id="colours-1" name="colours" type="radio" value="red">
+      <label class="govuk-label govuk-radios__label" for="colours-1">
+        Red
+      </label>
+    </div>
+
+    <div class="govuk-radios__item">
+      <input class="govuk-radios__input" id="colours-2" name="colours" type="radio" value="green">
+      <label class="govuk-label govuk-radios__label" for="colours-2">
+        Green
+      </label>
+    </div>
+
+    <div class="govuk-radios__item">
+      <input class="govuk-radios__input" id="colours-3" name="colours" type="radio" value="blue">
+      <label class="govuk-label govuk-radios__label" for="colours-3">
+        Blue
+      </label>
+    </div>
+
+  </div>
+
+</div>
+"""
+        ).strip()
+    )

--- a/tests/components/test_select.py
+++ b/tests/components/test_select.py
@@ -1,0 +1,60 @@
+
+import pytest
+
+from govuk_frontend.templates import Environment
+
+
+def test_select():
+    env = Environment()
+    template = env.from_string(
+"""
+{% from "select/macro.njk" import govukSelect %}
+
+{{ govukSelect({
+  "id": "select-1",
+  "name": "select-1",
+  "label": {
+    "text": "Label text goes here"
+  },
+  "items": [
+    {
+      "value": 1,
+      "text": "GOV.UK frontend option 1"
+    },
+    {
+      "value": 2,
+      "text": "GOV.UK frontend option 2",
+      "selected": true
+    },
+    {
+      "value": 3,
+      "text": "GOV.UK frontend option 3",
+      "disabled": true
+    }
+  ]
+}) }}
+"""
+    )
+    assert (
+        pytest.helpers.normalise_whitespace(template.render())
+        ==
+        pytest.helpers.normalise_whitespace(
+"""
+<div class="govuk-form-group">
+  <label class="govuk-label" for="select-1">
+    Label text goes here
+  </label>
+
+  <select class="govuk-select" id="select-1" name="select-1">
+
+    <option value="1">GOV.UK frontend option 1</option>
+
+    <option value="2" selected>GOV.UK frontend option 2</option>
+
+    <option value="3" disabled>GOV.UK frontend option 3</option>
+
+  </select>
+</div>
+"""
+        )
+    )

--- a/tests/components/test_skip_link.py
+++ b/tests/components/test_skip_link.py
@@ -1,0 +1,24 @@
+
+import pytest
+
+
+def test_skip_link(env):
+    template = env.from_string(
+"""
+{% from "skip-link/macro.njk" import govukSkipLink %}
+
+{{ govukSkipLink({
+  "text": "Skip to main content",
+  "href": "#content"
+}) }}
+"""
+    )
+    assert (
+        pytest.helpers.normalise_whitespace(template.render())
+        ==
+        pytest.helpers.normalise_whitespace(
+"""
+<a href="#content" class="govuk-skip-link">Skip to main content</a>
+"""
+        )
+    )

--- a/tests/components/test_table.py
+++ b/tests/components/test_table.py
@@ -1,0 +1,345 @@
+
+import pytest
+
+
+def test_table(env):
+    template = env.from_string(
+"""
+{% from "table/macro.njk" import govukTable %}
+
+{{ govukTable({
+  "rows": [
+    [
+      {
+        "text": "January"
+      },
+      {
+        "text": "£85",
+        "format": "numeric"
+      },
+      {
+        "text": "£95",
+        "format": "numeric"
+      }
+    ],
+    [
+      {
+        "text": "February"
+      },
+      {
+        "text": "£75",
+        "format": "numeric"
+      },
+      {
+        "text": "£55",
+        "format": "numeric"
+      }
+    ],
+    [
+      {
+        "text": "March"
+      },
+      {
+        "text": "£165",
+        "format": "numeric"
+      },
+      {
+        "text": "£125",
+        "format": "numeric"
+      }
+    ]
+  ]
+}) }}
+"""
+    )
+    assert (
+        pytest.helpers.normalise_whitespace(template.render())
+        ==
+        pytest.helpers.normalise_whitespace(
+"""
+<table class="govuk-table">
+
+  <tbody class="govuk-table__body">
+
+    <tr class="govuk-table__row">
+
+      <td class="govuk-table__cell">January</td>
+
+      <td class="govuk-table__cell govuk-table__cell--numeric">£85</td>
+
+      <td class="govuk-table__cell govuk-table__cell--numeric">£95</td>
+
+    </tr>
+
+    <tr class="govuk-table__row">
+
+      <td class="govuk-table__cell">February</td>
+
+      <td class="govuk-table__cell govuk-table__cell--numeric">£75</td>
+
+      <td class="govuk-table__cell govuk-table__cell--numeric">£55</td>
+
+    </tr>
+
+    <tr class="govuk-table__row">
+
+      <td class="govuk-table__cell">March</td>
+
+      <td class="govuk-table__cell govuk-table__cell--numeric">£165</td>
+
+      <td class="govuk-table__cell govuk-table__cell--numeric">£125</td>
+
+    </tr>
+
+  </tbody>
+</table>
+"""
+        )
+    )
+
+
+def test_table_with_head(env):
+    template = env.from_string(
+"""
+{% from "table/macro.njk" import govukTable %}
+
+{{ govukTable({
+  "head": [
+    {
+      "text": "Month you apply"
+    },
+    {
+      "text": "Rate for bicycles",
+      "format": "numeric"
+    },
+    {
+      "text": "Rate for vehicles",
+      "format": "numeric"
+    }
+  ],
+  "rows": [
+    [
+      {
+        "text": "January"
+      },
+      {
+        "text": "£85",
+        "format": "numeric"
+      },
+      {
+        "text": "£95",
+        "format": "numeric"
+      }
+    ],
+    [
+      {
+        "text": "February"
+      },
+      {
+        "text": "£75",
+        "format": "numeric"
+      },
+      {
+        "text": "£55",
+        "format": "numeric"
+      }
+    ],
+    [
+      {
+        "text": "March"
+      },
+      {
+        "text": "£165",
+        "format": "numeric"
+      },
+      {
+        "text": "£125",
+        "format": "numeric"
+      }
+    ]
+  ]
+}) }}
+"""
+    )
+    assert (
+        pytest.helpers.normalise_whitespace(template.render())
+        ==
+        pytest.helpers.normalise_whitespace(
+"""
+<table class="govuk-table">
+
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+
+      <th class="govuk-table__header" scope="col">Month you apply</th>
+
+      <th class="govuk-table__header govuk-table__header--numeric" scope="col">Rate for bicycles</th>
+
+      <th class="govuk-table__header govuk-table__header--numeric" scope="col">Rate for vehicles</th>
+
+    </tr>
+  </thead>
+
+  <tbody class="govuk-table__body">
+
+    <tr class="govuk-table__row">
+
+      <td class="govuk-table__cell">January</td>
+
+      <td class="govuk-table__cell govuk-table__cell--numeric">£85</td>
+
+      <td class="govuk-table__cell govuk-table__cell--numeric">£95</td>
+
+    </tr>
+
+    <tr class="govuk-table__row">
+
+      <td class="govuk-table__cell">February</td>
+
+      <td class="govuk-table__cell govuk-table__cell--numeric">£75</td>
+
+      <td class="govuk-table__cell govuk-table__cell--numeric">£55</td>
+
+    </tr>
+
+    <tr class="govuk-table__row">
+
+      <td class="govuk-table__cell">March</td>
+
+      <td class="govuk-table__cell govuk-table__cell--numeric">£165</td>
+
+      <td class="govuk-table__cell govuk-table__cell--numeric">£125</td>
+
+    </tr>
+
+  </tbody>
+</table>
+"""
+        )
+    )
+
+
+def test_table_with_head_and_caption(env):
+    template = env.from_string(
+"""
+{% from "table/macro.njk" import govukTable %}
+
+{{ govukTable({
+  "caption": "Caption 1: Months and rates",
+  "captionClasses": "govuk-heading-m",
+  "firstCellIsHeader": true,
+  "head": [
+    {
+      "text": "Month you apply"
+    },
+    {
+      "text": "Rate for bicycles",
+      "format": "numeric"
+    },
+    {
+      "text": "Rate for vehicles",
+      "format": "numeric"
+    }
+  ],
+  "rows": [
+    [
+      {
+        "text": "January"
+      },
+      {
+        "text": "£85",
+        "format": "numeric"
+      },
+      {
+        "text": "£95",
+        "format": "numeric"
+      }
+    ],
+    [
+      {
+        "text": "February"
+      },
+      {
+        "text": "£75",
+        "format": "numeric"
+      },
+      {
+        "text": "£55",
+        "format": "numeric"
+      }
+    ],
+    [
+      {
+        "text": "March"
+      },
+      {
+        "text": "£165",
+        "format": "numeric"
+      },
+      {
+        "text": "£125",
+        "format": "numeric"
+      }
+    ]
+  ]
+}) }}
+"""
+    )
+    assert (
+        pytest.helpers.normalise_whitespace(template.render())
+        ==
+        pytest.helpers.normalise_whitespace(
+"""
+<table class="govuk-table">
+
+  <caption class="govuk-table__caption govuk-heading-m">Caption 1: Months and rates</caption>
+
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+
+      <th class="govuk-table__header" scope="col">Month you apply</th>
+
+      <th class="govuk-table__header govuk-table__header--numeric" scope="col">Rate for bicycles</th>
+
+      <th class="govuk-table__header govuk-table__header--numeric" scope="col">Rate for vehicles</th>
+
+    </tr>
+  </thead>
+
+  <tbody class="govuk-table__body">
+
+    <tr class="govuk-table__row">
+
+      <th class="govuk-table__header" scope="row">January</th>
+
+      <td class="govuk-table__cell govuk-table__cell--numeric">£85</td>
+
+      <td class="govuk-table__cell govuk-table__cell--numeric">£95</td>
+
+    </tr>
+
+    <tr class="govuk-table__row">
+
+      <th class="govuk-table__header" scope="row">February</th>
+
+      <td class="govuk-table__cell govuk-table__cell--numeric">£75</td>
+
+      <td class="govuk-table__cell govuk-table__cell--numeric">£55</td>
+
+    </tr>
+
+    <tr class="govuk-table__row">
+
+      <th class="govuk-table__header" scope="row">March</th>
+
+      <td class="govuk-table__cell govuk-table__cell--numeric">£165</td>
+
+      <td class="govuk-table__cell govuk-table__cell--numeric">£125</td>
+
+    </tr>
+
+  </tbody>
+</table>
+"""
+        )
+    )

--- a/tests/components/test_tabs.py
+++ b/tests/components/test_tabs.py
@@ -1,0 +1,290 @@
+
+import pytest
+
+
+def test_tabs(env):
+    template = env.from_string(
+r"""
+{% from "tabs/macro.njk" import govukTabs %}
+
+{{ govukTabs({
+  "items": [
+    {
+      "label": "Past day",
+      "id": "past-day",
+      "panel": {
+        "html": "<h2 class=\"govuk-heading-l\">Past day</h2>\n<table class=\"govuk-table\">\n  <thead class=\"govuk-table__head\">\n    <tr class=\"govuk-table__row\">\n      <th class=\"govuk-table__header\" scope=\"col\">Case manager</th>\n      <th class=\"govuk-table__header\" scope=\"col\">Cases opened</th>\n      <th class=\"govuk-table__header\" scope=\"col\">Cases closed</th>\n    </tr>\n  </thead>\n  <tbody class=\"govuk-table__body\">\n    <tr class=\"govuk-table__row\">\n      <td class=\"govuk-table__cell\">David Francis</td>\n      <td class=\"govuk-table__cell\">3</td>\n      <td class=\"govuk-table__cell\">0</td>\n    </tr>\n    <tr class=\"govuk-table__row\">\n      <td class=\"govuk-table__cell\">Paul Farmer</td>\n      <td class=\"govuk-table__cell\">1</td>\n      <td class=\"govuk-table__cell\">0</td>\n    </tr>\n    <tr class=\"govuk-table__row\">\n      <td class=\"govuk-table__cell\">Rita Patel</td>\n      <td class=\"govuk-table__cell\">2</td>\n      <td class=\"govuk-table__cell\">0</td>\n    </tr>\n  </tbody>\n</table>\n"
+      }
+    },
+    {
+      "label": "Past week",
+      "id": "past-week",
+      "panel": {
+        "html": "<h2 class=\"govuk-heading-l\">Past week</h2>\n<table class=\"govuk-table\">\n  <thead class=\"govuk-table__head\">\n    <tr class=\"govuk-table__row\">\n      <th class=\"govuk-table__header\" scope=\"col\">Case manager</th>\n      <th class=\"govuk-table__header\" scope=\"col\">Cases opened</th>\n      <th class=\"govuk-table__header\" scope=\"col\">Cases closed</th>\n    </tr>\n  </thead>\n  <tbody class=\"govuk-table__body\">\n    <tr class=\"govuk-table__row\">\n      <td class=\"govuk-table__cell\">David Francis</td>\n      <td class=\"govuk-table__cell\">24</td>\n      <td class=\"govuk-table__cell\">18</td>\n    </tr>\n    <tr class=\"govuk-table__row\">\n      <td class=\"govuk-table__cell\">Paul Farmer</td>\n      <td class=\"govuk-table__cell\">16</td>\n      <td class=\"govuk-table__cell\">20</td>\n    </tr>\n    <tr class=\"govuk-table__row\">\n      <td class=\"govuk-table__cell\">Rita Patel</td>\n      <td class=\"govuk-table__cell\">24</td>\n      <td class=\"govuk-table__cell\">27</td>\n    </tr>\n  </tbody>\n</table>\n"
+      }
+    },
+    {
+      "label": "Past month",
+      "id": "past-month",
+      "panel": {
+        "html": "<h2 class=\"govuk-heading-l\">Past month</h2>\n<table class=\"govuk-table\">\n  <thead class=\"govuk-table__head\">\n    <tr class=\"govuk-table__row\">\n      <th class=\"govuk-table__header\" scope=\"col\">Case manager</th>\n      <th class=\"govuk-table__header\" scope=\"col\">Cases opened</th>\n      <th class=\"govuk-table__header\" scope=\"col\">Cases closed</th>\n    </tr>\n  </thead>\n  <tbody class=\"govuk-table__body\">\n    <tr class=\"govuk-table__row\">\n      <td class=\"govuk-table__cell\">David Francis</td>\n      <td class=\"govuk-table__cell\">98</td>\n      <td class=\"govuk-table__cell\">95</td>\n    </tr>\n    <tr class=\"govuk-table__row\">\n      <td class=\"govuk-table__cell\">Paul Farmer</td>\n      <td class=\"govuk-table__cell\">122</td>\n      <td class=\"govuk-table__cell\">131</td>\n    </tr>\n    <tr class=\"govuk-table__row\">\n      <td class=\"govuk-table__cell\">Rita Patel</td>\n      <td class=\"govuk-table__cell\">126</td>\n      <td class=\"govuk-table__cell\">142</td>\n    </tr>\n  </tbody>\n</table>\n"
+      }
+    },
+    {
+      "label": "Past year",
+      "id": "past-year",
+      "panel": {
+        "html": "<h2 class=\"govuk-heading-l\">Past year</h2>\n<table class=\"govuk-table\">\n  <thead class=\"govuk-table__head\">\n    <tr class=\"govuk-table__row\">\n      <th class=\"govuk-table__header\" scope=\"col\">Case manager</th>\n      <th class=\"govuk-table__header\" scope=\"col\">Cases opened</th>\n      <th class=\"govuk-table__header\" scope=\"col\">Cases closed</th>\n    </tr>\n  </thead>\n  <tbody class=\"govuk-table__body\">\n    <tr class=\"govuk-table__row\">\n      <td class=\"govuk-table__cell\">David Francis</td>\n      <td class=\"govuk-table__cell\">1380</td>\n      <td class=\"govuk-table__cell\">1472</td>\n    </tr>\n    <tr class=\"govuk-table__row\">\n      <td class=\"govuk-table__cell\">Paul Farmer</td>\n      <td class=\"govuk-table__cell\">1129</td>\n      <td class=\"govuk-table__cell\">1083</td>\n    </tr>\n    <tr class=\"govuk-table__row\">\n      <td class=\"govuk-table__cell\">Rita Patel</td>\n      <td class=\"govuk-table__cell\">1539</td>\n      <td class=\"govuk-table__cell\">1265</td>\n    </tr>\n  </tbody>\n</table>\n"
+      }
+    }
+  ]
+}) }}
+"""
+    )
+    assert (
+        pytest.helpers.normalise_whitespace(template.render())
+        ==
+        pytest.helpers.normalise_whitespace(
+"""
+<div class="govuk-tabs" data-module="tabs">
+  <h2 class="govuk-tabs__title">
+    Contents
+  </h2>
+
+  <ul class="govuk-tabs__list">
+
+      <li class="govuk-tabs__list-item">
+        <a class="govuk-tabs__tab govuk-tabs__tab--selected" href="#past-day">
+          Past day
+        </a>
+      </li>
+
+      <li class="govuk-tabs__list-item">
+        <a class="govuk-tabs__tab" href="#past-week">
+          Past week
+        </a>
+      </li>
+
+      <li class="govuk-tabs__list-item">
+        <a class="govuk-tabs__tab" href="#past-month">
+          Past month
+        </a>
+      </li>
+
+      <li class="govuk-tabs__list-item">
+        <a class="govuk-tabs__tab" href="#past-year">
+          Past year
+        </a>
+      </li>
+
+  </ul>
+
+  <section class="govuk-tabs__panel" id="past-day">
+    <h2 class="govuk-heading-l">Past day</h2>
+<table class="govuk-table">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th class="govuk-table__header" scope="col">Case manager</th>
+      <th class="govuk-table__header" scope="col">Cases opened</th>
+      <th class="govuk-table__header" scope="col">Cases closed</th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">David Francis</td>
+      <td class="govuk-table__cell">3</td>
+      <td class="govuk-table__cell">0</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">Paul Farmer</td>
+      <td class="govuk-table__cell">1</td>
+      <td class="govuk-table__cell">0</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">Rita Patel</td>
+      <td class="govuk-table__cell">2</td>
+      <td class="govuk-table__cell">0</td>
+    </tr>
+  </tbody>
+</table>
+
+  </section>
+
+  <section class="govuk-tabs__panel govuk-tabs__panel--hidden" id="past-week">
+    <h2 class="govuk-heading-l">Past week</h2>
+<table class="govuk-table">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th class="govuk-table__header" scope="col">Case manager</th>
+      <th class="govuk-table__header" scope="col">Cases opened</th>
+      <th class="govuk-table__header" scope="col">Cases closed</th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">David Francis</td>
+      <td class="govuk-table__cell">24</td>
+      <td class="govuk-table__cell">18</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">Paul Farmer</td>
+      <td class="govuk-table__cell">16</td>
+      <td class="govuk-table__cell">20</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">Rita Patel</td>
+      <td class="govuk-table__cell">24</td>
+      <td class="govuk-table__cell">27</td>
+    </tr>
+  </tbody>
+</table>
+
+  </section>
+
+  <section class="govuk-tabs__panel govuk-tabs__panel--hidden" id="past-month">
+    <h2 class="govuk-heading-l">Past month</h2>
+<table class="govuk-table">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th class="govuk-table__header" scope="col">Case manager</th>
+      <th class="govuk-table__header" scope="col">Cases opened</th>
+      <th class="govuk-table__header" scope="col">Cases closed</th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">David Francis</td>
+      <td class="govuk-table__cell">98</td>
+      <td class="govuk-table__cell">95</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">Paul Farmer</td>
+      <td class="govuk-table__cell">122</td>
+      <td class="govuk-table__cell">131</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">Rita Patel</td>
+      <td class="govuk-table__cell">126</td>
+      <td class="govuk-table__cell">142</td>
+    </tr>
+  </tbody>
+</table>
+
+  </section>
+
+  <section class="govuk-tabs__panel govuk-tabs__panel--hidden" id="past-year">
+    <h2 class="govuk-heading-l">Past year</h2>
+<table class="govuk-table">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th class="govuk-table__header" scope="col">Case manager</th>
+      <th class="govuk-table__header" scope="col">Cases opened</th>
+      <th class="govuk-table__header" scope="col">Cases closed</th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">David Francis</td>
+      <td class="govuk-table__cell">1380</td>
+      <td class="govuk-table__cell">1472</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">Paul Farmer</td>
+      <td class="govuk-table__cell">1129</td>
+      <td class="govuk-table__cell">1083</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">Rita Patel</td>
+      <td class="govuk-table__cell">1539</td>
+      <td class="govuk-table__cell">1265</td>
+    </tr>
+  </tbody>
+</table>
+
+  </section>
+
+</div>
+"""
+        )
+    )
+
+
+def test_tabs_simple(env):
+    template = env.from_string(
+"""
+{% from "tabs/macro.njk" import govukTabs %}
+
+{{ govukTabs({
+  "items": [
+    {
+      "label": "Past day",
+      "id": "past-day",
+      "panel": {
+        "text": "Yesterday"
+      }
+    },
+    {
+      "label": "This day",
+      "id": "this-day",
+      "panel": {
+        "text": "Today"
+      }
+    },
+    {
+      "label": "Next day",
+      "id": "next-day",
+      "panel": {
+        "text": "Tomorrow"
+      }
+    },
+  ]
+}) }}
+"""
+    )
+    assert (
+        pytest.helpers.normalise_whitespace(template.render())
+        ==
+        pytest.helpers.normalise_whitespace(
+"""
+<div class="govuk-tabs" data-module="tabs">
+  <h2 class="govuk-tabs__title">
+    Contents
+  </h2>
+
+  <ul class="govuk-tabs__list">
+
+      <li class="govuk-tabs__list-item">
+        <a class="govuk-tabs__tab govuk-tabs__tab--selected" href="#past-day">
+          Past day
+        </a>
+      </li>
+
+      <li class="govuk-tabs__list-item">
+        <a class="govuk-tabs__tab" href="#this-day">
+          This day
+        </a>
+      </li>
+
+      <li class="govuk-tabs__list-item">
+        <a class="govuk-tabs__tab" href="#next-day">
+          Next day
+        </a>
+      </li>
+
+  </ul>
+
+  <section class="govuk-tabs__panel" id="past-day">
+    Yesterday
+  </section>
+
+  <section class="govuk-tabs__panel govuk-tabs__panel--hidden" id="this-day">
+    Today
+  </section>
+
+  <section class="govuk-tabs__panel govuk-tabs__panel--hidden" id="next-day">
+    Tomorrow
+  </section>
+</div>
+"""
+        )
+    )

--- a/tests/components/test_tag.py
+++ b/tests/components/test_tag.py
@@ -1,0 +1,49 @@
+
+import pytest
+
+
+def test_tag(env):
+    template = env.from_string(
+"""
+{% from "tag/macro.njk" import govukTag %}
+
+{{ govukTag({
+  "text": "alpha"
+}) }}
+"""
+    )
+    assert (
+        pytest.helpers.normalise_whitespace(template.render())
+        ==
+        pytest.helpers.normalise_whitespace(
+"""
+<strong class="govuk-tag">
+  alpha
+</strong>
+"""
+        )
+    )
+
+
+def test_tag_inactive(env):
+    template = env.from_string(
+"""
+{% from "tag/macro.njk" import govukTag %}
+
+{{ govukTag({
+  "text": "alpha",
+  "classes": "govuk-tag--inactive"
+}) }}
+"""
+    )
+    assert (
+        pytest.helpers.normalise_whitespace(template.render())
+        ==
+        pytest.helpers.normalise_whitespace(
+"""
+<strong class="govuk-tag govuk-tag--inactive">
+  alpha
+</strong>
+"""
+        )
+    )

--- a/tests/components/test_textarea.py
+++ b/tests/components/test_textarea.py
@@ -1,0 +1,144 @@
+
+import pytest
+
+
+@pytest.mark.xfail(reason="apostrophe not escaped")
+def test_textarea(env):
+    template = env.from_string(
+"""
+{% from "textarea/macro.njk" import govukTextarea %}
+
+{{ govukTextarea({
+  "name": "more-detail",
+  "id": "more-detail",
+  "label": {
+    "text": "Can you provide more detail?"
+  },
+  "hint": {
+    "text": "Don't include personal or financial information, eg your National Insurance number or credit card details."
+  }
+}) }}
+"""
+    )
+    assert (
+        pytest.helpers.normalise_whitespace(template.render())
+        ==
+        pytest.helpers.normalise_whitespace(
+"""
+<div class="govuk-form-group">
+  <label class="govuk-label" for="more-detail">
+    Can you provide more detail?
+  </label>
+
+  <span id="more-detail-hint" class="govuk-hint">
+    Don&#39;t include personal or financial information, eg your National Insurance number or credit card details.
+  </span>
+
+  <textarea class="govuk-textarea" id="more-detail" name="more-detail" rows="5" aria-describedby="more-detail-hint"></textarea>
+</div>
+"""
+        )
+    )
+
+
+def test_textarea_with_default_value(env):
+    template = env.from_string(
+"""
+{% from "textarea/macro.njk" import govukTextarea %}
+
+{{ govukTextarea({
+  "id": "full-address",
+  "name": "address",
+  "value": "221B Baker Street\nLondon\nNW1 6XE\n",
+  "label": {
+    "text": "Full address"
+  }
+}) }}
+"""
+    )
+    assert (
+        pytest.helpers.normalise_whitespace(template.render())
+        ==
+        pytest.helpers.normalise_whitespace(
+"""
+<div class="govuk-form-group">
+  <label class="govuk-label" for="full-address">
+    Full address
+  </label>
+
+  <textarea class="govuk-textarea" id="full-address" name="address" rows="5">221B Baker Street
+London
+NW1 6XE
+</textarea>
+</div>
+"""
+        )
+    )
+
+
+def test_textarea_with_custom_rows(env):
+    template = env.from_string(
+"""
+{% from "textarea/macro.njk" import govukTextarea %}
+
+{{ govukTextarea({
+  "id": "full-address",
+  "name": "address",
+  "label": {
+    "text": "Full address"
+  },
+  "rows": 8
+}) }}
+"""
+    )
+    assert (
+        pytest.helpers.normalise_whitespace(template.render())
+        ==
+        pytest.helpers.normalise_whitespace(
+"""
+<div class="govuk-form-group">
+  <label class="govuk-label" for="full-address">
+    Full address
+  </label>
+
+  <textarea class="govuk-textarea" id="full-address" name="address" rows="8"></textarea>
+</div>
+"""
+        )
+    )
+
+
+@pytest.mark.xfail(reason="autoescape required, HTML entities being escaped")
+def test_textarea_with_label_as_page_heading(env):
+    template = env.from_string(
+"""
+{% from "textarea/macro.njk" import govukTextarea %}
+
+{{ govukTextarea({
+  "id": "textarea-with-page-heading",
+  "name": "address",
+  "label": {
+    "text": "Full address",
+    "isPageHeading": true
+  }
+}) }}
+"""
+    )
+    assert (
+        pytest.helpers.normalise_whitespace(template.render())
+        ==
+        pytest.helpers.normalise_whitespace(
+"""
+<div class="govuk-form-group">
+  <h1 class="govuk-label-wrapper">
+    <label class="govuk-label" for="textarea-with-page-heading">
+      Full address
+    </label>
+
+  </h1>
+
+  <textarea class="govuk-textarea" id="textarea-with-page-heading" name="address" rows="5"></textarea>
+</div>
+"""
+        )
+    )

--- a/tests/components/test_warning_text.py
+++ b/tests/components/test_warning_text.py
@@ -1,0 +1,30 @@
+
+import pytest
+
+
+def test_warning_text(env):
+    template = env.from_string(
+"""
+{% from "warning-text/macro.njk" import govukWarningText %}
+
+{{ govukWarningText({
+  "text": "You can be fined up to £5,000 if you don’t register.",
+  "iconFallbackText": "Warning"
+}) }}
+"""
+    )
+    assert (
+        pytest.helpers.normalise_whitespace(template.render())
+        ==
+        pytest.helpers.normalise_whitespace(
+"""
+<div class="govuk-warning-text">
+  <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+  <strong class="govuk-warning-text__text">
+    <span class="govuk-warning-text__assistive">Warning</span>
+    You can be fined up to £5,000 if you don’t register.
+  </strong>
+</div>
+"""
+        )
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ pytest_plugins = ['helpers_namespace']
 
 import pytest
 
+from itertools import filterfalse
 import re
 from typing import Iterator, Union, TextIO
 
@@ -20,5 +21,5 @@ def readlines(buf: Union[str, TextIO]) -> Iterator[str]:
 @pytest.helpers.register
 def normalise_whitespace(buf: Union[str, TextIO]) -> str:
     """Delete lines that are empty/contain only whitespace"""
-    lines = filter(IS_LINE_JUNK, readlines(buf))
+    lines = filterfalse(IS_LINE_JUNK, readlines(buf))
     return ''.join(lines)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ import pytest
 
 from itertools import filterfalse
 import re
+from textwrap import dedent
 from typing import Iterator, Union, TextIO
 
 @pytest.helpers.register
@@ -22,4 +23,4 @@ def readlines(buf: Union[str, TextIO]) -> Iterator[str]:
 def normalise_whitespace(buf: Union[str, TextIO]) -> str:
     """Delete lines that are empty/contain only whitespace"""
     lines = filterfalse(IS_LINE_JUNK, readlines(buf))
-    return ''.join(lines)
+    return dedent(''.join(lines)).strip()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,9 @@ import re
 from textwrap import dedent
 from typing import Iterator, Union, TextIO
 
+import govuk_frontend.templates
+
+
 @pytest.helpers.register
 def IS_LINE_JUNK(line):
     return bool(re.match(r'^\s*$', line))
@@ -24,3 +27,8 @@ def normalise_whitespace(buf: Union[str, TextIO]) -> str:
     """Delete lines that are empty/contain only whitespace"""
     lines = filterfalse(IS_LINE_JUNK, readlines(buf))
     return dedent(''.join(lines)).strip()
+
+
+@pytest.fixture
+def env():
+    return govuk_frontend.templates.Environment()

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -16,3 +16,26 @@ class TestNunjucksUndefined:
     @pytest.fixture
     def env(self):
         return jinja2.Environment(undefined=NunjucksUndefined)
+
+    def test_undefined_is_chainable(self, env):
+        template = env.from_string("{{ item.hint.text }}")
+        assert (
+            template.render(item={"hint": {"text": "foobar"}})
+            ==
+            "foobar"
+        )
+        assert (
+            template.render(item={"hint": {}})
+            ==
+            ""
+        )
+        assert (
+            template.render(item={})
+            ==
+            ""
+        )
+        assert (
+            template.render()
+            ==
+            ""
+        )

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -1,0 +1,8 @@
+
+from govuk_frontend.templates import Environment
+
+
+def test_environment_contains_govuk_frontend_templates_which_can_be_rendered():
+    env = Environment()
+    template = env.get_template("template.njk")
+    assert template.render()

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -1,8 +1,18 @@
 
-from govuk_frontend.templates import Environment
+import pytest
+
+import jinja2
+from govuk_frontend.templates import Environment, NunjucksUndefined
 
 
 def test_environment_contains_govuk_frontend_templates_which_can_be_rendered():
     env = Environment()
     template = env.get_template("template.njk")
     assert template.render()
+
+
+class TestNunjucksUndefined:
+    
+    @pytest.fixture
+    def env(self):
+        return jinja2.Environment(undefined=NunjucksUndefined)

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -1,0 +1,55 @@
+
+import pytest
+from unittest import mock
+
+import jinja2
+from govuk_frontend.templates import NunjucksExtension
+
+
+@pytest.fixture(autouse=True)
+def njk_to_j2():
+    with mock.patch("govuk_frontend.templates.njk_to_j2") as m:
+        yield m
+
+
+class TestExtension:
+    @pytest.fixture
+    def ext(self):
+        return jinja2.Environment()
+
+    def test_preprocesses_nunjucks_templates(self, env, njk_to_j2):
+        ext = NunjucksExtension(env)
+        assert ext.preprocess("foo", "bar", "baz.njk") == njk_to_j2("foo")
+
+    def test_does_not_preprocess_jinja_templates(self, env, njk_to_j2):
+        ext = NunjucksExtension(env)
+        assert ext.preprocess("foo", "bar", "baz.j2") == "foo"
+        assert njk_to_j2.call_count == 0
+
+    def test_does_not_preprocess_template_from_memory(self, env, njk_to_j2):
+        ext = NunjucksExtension(env)
+        assert ext.preprocess("foo", "bar") == "foo"
+        assert njk_to_j2.call_count == 0
+
+
+class TestExtensionWithFileSystemLoader:
+    @pytest.fixture
+    def env(self, tmpdir):
+        return jinja2.Environment(
+            extensions=[NunjucksExtension],
+            loader=jinja2.FileSystemLoader([tmpdir]),
+        )
+
+    def test_preprocesses_nunjucks_template(self, env, tmpdir, njk_to_j2):
+        template_file = tmpdir.join("template.njk")
+        template_file.write("foobar")
+        env.get_template("template.njk")
+        assert njk_to_j2.call_count == 1
+        assert njk_to_j2.call_args == mock.call("foobar")
+
+
+    def test_does_not_preprocess_jinja_templates(self, env, tmpdir, njk_to_j2):
+        template_file = tmpdir.join("template.j2")
+        template_file.write("foobar")
+        env.get_template("template.j2")
+        assert njk_to_j2.call_count == 0

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,20 @@
+
+import pytest
+
+def test_normalise_whitespace():
+    assert (
+        pytest.helpers.normalise_whitespace(
+"""
+
+  Hello world
+  
+  
+  
+  This is a line below a bunch of lines which are empty except for whitespace.
+"""
+        )
+        ==
+"""  Hello world
+  This is a line below a bunch of lines which are empty except for whitespace.
+"""
+    )

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,20 +1,44 @@
 
 import pytest
 
-def test_normalise_whitespace():
+def test_normalise_whitespace_deletes_empty_lines():
     assert (
         pytest.helpers.normalise_whitespace(
 """
-
-  Hello world
+Hello world
   
   
   
-  This is a line below a bunch of lines which are empty except for whitespace.
+This is a line below a bunch of lines which are empty except for whitespace.
 """
         )
         ==
-"""  Hello world
-  This is a line below a bunch of lines which are empty except for whitespace.
-"""
+        "Hello world\nThis is a line below a bunch of lines which are empty except for whitespace."
+    )
+
+
+def test_normalise_whitespace_dedents():
+    assert (
+        pytest.helpers.normalise_whitespace(
+            """
+            This is a multiline string which has been indented
+            in the Python source code for readability.
+            """
+        )
+        ==
+"""This is a multiline string which has been indented\nin the Python source code for readability."""
+    )
+
+
+@pytest.mark.xfail
+def test_normalise_whitespace_can_be_imported_with_another_name():
+    from pytest.helpers import normalise_whitespace as s
+    assert (
+        s("""
+        What's going on?
+
+        I don't know.
+        """)
+        ==
+        "What's going on?\nI don't know."
     )

--- a/tests/test_template/test_template.py
+++ b/tests/test_template/test_template.py
@@ -4,6 +4,7 @@ import pytest
 import govuk_frontend.templates
 
 
+@pytest.mark.xfail
 @pytest.mark.datafiles('tests/test_template/template_njk.expected.html')
 def test_template_njk(datafiles):
     env = govuk_frontend.templates.Environment()
@@ -15,6 +16,7 @@ def test_template_njk(datafiles):
         template = pytest.helpers.normalise_whitespace(template)
         assert expected == template
 
+@pytest.mark.xfail
 @pytest.mark.datafiles(
     'tests/test_template/extends_template_njk.input.j2',
     'tests/test_template/extends_template_njk.expected.html',

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -80,3 +80,11 @@ def test_patches_govuk_fieldset_definition():
         ==
         "{% macro govukFieldset(params, caller=none) %}{% endmacro %}"
     )
+
+
+def test_patches_iteration_of_params_attributes():
+    assert (
+        njk_to_j2("{%- for attribute, value in params.attributes %}{% endfor -%}")
+        ==
+        "{%- for attribute, value in params.attributes.items() %}{% endfor -%}"
+    )

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -72,3 +72,11 @@ def test_quotes_dictionary_keys():
 }) }}
 """
     )
+
+
+def test_patches_govuk_fieldset_definition():
+    assert(
+        njk_to_j2("{% macro govukFieldset(params) %}{% endmacro %}")
+        ==
+        "{% macro govukFieldset(params, caller=none) %}{% endmacro %}"
+    )

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -38,3 +38,17 @@ def test_replaces_add_loop_index_with_concatenate():
 {% endfor %}
 """
     )
+
+
+@pytest.mark.parametrize(
+    ("input, expected_output"),
+    (
+        ("{% ' ' + item if item %}", "{% ' ' + item if item else '' %}"),
+        ("{% ' ' + (item if item) %}", "{% ' ' + (item if item else '') %}"),
+        pytest.param("{% 'hello ' + (' world' if item) %}", "{% 'hello ' + (' world' if item else '') %}", marks=pytest.mark.xfail),
+        ("{% ' ' + item if item else '' %}", "{% ' ' + item if item else '' %}"),
+        ("{% ' ' + (item if item else '') %}", "{% ' ' + (item if item else '') %}"),
+    ),
+)
+def test_adds_else_statement_to_inline_if_expressions(input, expected_output):
+    assert njk_to_j2(input) == expected_output

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -4,3 +4,19 @@ import pytest
 from govuk_frontend.templates import njk_to_j2
 
 
+def test_replaces_items_getattr_with_getitem():
+    assert (
+        njk_to_j2 (
+"""
+{% for item in params.items %}
+  item
+{% endfor %}
+"""
+        )
+        ==
+"""
+{% for item in params['items'] %}
+  item
+{% endfor %}
+"""
+    )

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -1,10 +1,6 @@
 
 import pytest
 
-import govuk_frontend.templates
+from govuk_frontend.templates import njk_to_j2
 
 
-def test_environment_contains_govuk_frontend_templates_which_can_be_rendered():
-    env = govuk_frontend.templates.Environment()
-    template = env.get_template("template.njk")
-    assert template.render()

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -20,3 +20,21 @@ def test_replaces_items_getattr_with_getitem():
 {% endfor %}
 """
     )
+
+
+def test_replaces_add_loop_index_with_concatenate():
+    assert (
+        njk_to_j2(
+"""
+{% for item in items %}
+  "item " + loop.index
+{% endfor %}
+"""
+        )
+        ==
+"""
+{% for item in items %}
+  "item " ~ loop.index
+{% endfor %}
+"""
+    )

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -52,3 +52,23 @@ def test_replaces_add_loop_index_with_concatenate():
 )
 def test_adds_else_statement_to_inline_if_expressions(input, expected_output):
     assert njk_to_j2(input) == expected_output
+
+
+def test_quotes_dictionary_keys():
+    assert (
+        njk_to_j2(
+"""
+{{ macro({
+  param: 'foo',
+  value: 'bar'
+}) }}
+"""
+        )
+        ==
+"""
+{{ macro({
+  'param': 'foo',
+  'value': 'bar'
+}) }}
+"""
+    )


### PR DESCRIPTION
## New features

- Add tests for all components
- Add an extension `NunjucksExtension` that preprocesses Nunjucks templates
- Add an subclass of Undefined, `NunjucksUndefined`, that deals with instances where Nunjucks is more forgiving that Jinja
- Create an example of a Jinja Environment that handles almost all incompatibilities between Nunjucks and Jinja in the govuk-frontend templates
- Add a command-line tool, `scripts/njk-to-j2.py` that can be used for debugging the extension

## Bugfixes

- Fix bug with test helper `normalise_whitespace`