### PR TITLE
Fix bug with `join_path`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Bugfixes
+
+* Fix bug with `join_path`
+
 2019-08-13 version 0.1.0-alpha
 
 ## New features

--- a/govuk_frontend/templates.py
+++ b/govuk_frontend/templates.py
@@ -116,4 +116,7 @@ class Environment(jinja2.Environment):
 
     def join_path(self, template, parent):
         """Enable the use of relative paths in template import statements"""
-        return path.normpath(path.join(path.dirname(parent), template))
+        if template.startswith(("./", "../")):
+            return path.normpath(path.join(path.dirname(parent), template))
+        else:
+            return template

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -11,6 +11,31 @@ def test_environment_contains_govuk_frontend_templates_which_can_be_rendered():
     assert template.render()
 
 
+class TestJoinPath:
+
+    @pytest.fixture
+    def env(self):
+        return Environment(
+            loader=jinja2.DictLoader({
+                "a/a/a.njk": "{% include './b.njk' %}",
+                "a/a/b.njk": "b",
+                "a/b/b.njk": "{% include '../a/b.njk' %}",
+                "c/c.html": "{% include 'a/a/a.njk' %}",
+            })
+        )
+
+    def test_join_path_joins_relative_paths(self, env):
+        template = env.get_template("a/a/a.njk")
+        assert template.render() == "b"
+
+        template = env.get_template("a/b/b.njk")
+        assert template.render() == "b"
+
+    def test_join_path_does_not_join_unanchored_paths(self, env):
+        template = env.get_template("c/c.html")
+        assert template.render() == "b"
+
+
 class TestNunjucksUndefined:
     
     @pytest.fixture


### PR DESCRIPTION
`join_path` was trying to join paths even when the path wasn't relative
(i.e. didn't start with `./` or `../`). This commit fixes this and adds tests.